### PR TITLE
MLX support + Anthropic proxy + backend parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,12 +29,12 @@ CLI/API → Proxy (port 11313) → Routes by model name → backend servers (:49
 ```
 
 Key packages in `internal/proxy/`:
-- `server.go` - HTTP routing, reverse-proxy to backends, `/v1/chat/completions` pass-through
-- `anthropic.go` - In-proxy translation of `/v1/messages` ⇄ `/v1/chat/completions` so backends only need an OpenAI surface
-- `manager.go` - Model lifecycle (start/stop backend, LRU eviction, max 3 models)
-- `backend.go` - `Runtime` interface: `Kind`, `HFAppName`, `BinaryPath`, `WorkingDir`, `BuildArgs`, `HealthURL`, `IsStartupError`
+- `server.go` - HTTP routing, reverse-proxy to backends, `/v1/chat/completions` pass-through, shared body/model helpers (`readOpenAIBody`/`readAnthropicBody`)
+- `anthropic.go` - In-proxy translation of `/v1/messages` ⇄ `/v1/chat/completions` so backends only need an OpenAI surface. Covers tool-use (request + response + streaming), stop-sequence forwarding, image base64 (URL-source refused with 401 since backends don't fetch), error-type normalization, periodic `event: ping` frames (15s default) to survive nginx-style idle timeouts
+- `manager.go` - Model lifecycle (start/stop backend, LRU eviction, max 3 models). `optionsChanged` delegates to `Runtime.SignificantOptions()` so reload-worthy key sets are a per-backend concern
+- `backend.go` - `Runtime` interface: `Kind`, `HFAppName`, `BinaryPath`, `WorkingDir`, `BuildArgs`, `HealthURL`, `IsStartupError`, `SignificantOptions`
 - `backend_llama.go`, `backend_swiftlm.go` - Concrete runtimes
-- `backend_select.go` - Reads `metadata.yaml` backend kind → picks the runtime
+- `backend_select.go` - Reads `metadata.yaml` backend kind → picks the runtime (fails closed on unknown kinds via `hf.parseBackendKind`)
 - `registry.go` - `AllRuntimes` / `HFAppNames` (single registration point for a new backend)
 - `idle.go` - Background monitor for auto-unloading idle models
 - `ports.go` - Dynamic port allocation for backends
@@ -43,7 +43,9 @@ Key packages in `internal/proxy/`:
 
 Each backend is a `Runtime` that owns its binary, args, health probe, and error log scan. Adding a new backend means (1) implement `Runtime`, (2) add its constructor to `AllRuntimes()` in `registry.go`, (3) add a `case` in `selectRuntime` for its `metadata.yaml` kind, (4) optionally a config section under a new YAML key to mirror `llamacpp:` / `swiftlm:`. Nothing in `cmd/` or the discovery surface hardcodes a backend list — `cmd/search.go` joins every registered `HFAppName` for the `?apps=` filter.
 
-**Security-sensitive install code is shared**: `internal/binaryrelease/` owns URL host/scheme allow-lists, download size caps, atomic symlink swap (`swiftlm-current` / `llama-current`), and a validating tar extractor (no path traversal, no escaping symlinks). Each backend installer (`internal/llama/binary.go`, `internal/swiftlm/binary.go`) wraps these primitives with its own repo URL, platform matrix, and `version.json` sibling file.
+**Security-sensitive install code is shared**: `internal/binaryrelease/` owns URL host/scheme allow-lists, download size caps, atomic symlink swap (`swiftlm-current` / `llama-current`), and a validating tar extractor (no path traversal, no escaping symlinks). `binaryrelease.SafeJoin` is also used by `internal/hf/mlx.go` to guard against malicious HuggingFace tree entries writing outside the model directory. Each backend installer (`internal/llama/binary.go`, `internal/swiftlm/binary.go`) wraps these primitives with its own repo URL, platform matrix, and `version.json` sibling file.
+
+HuggingFace downloads enforce their own redirect allow-list (`hfAllowedHosts` in `internal/hf/client.go` — huggingface.co + the LFS / xethub CDN hosts) and a per-file size cap derived from the manifest-declared size (2× tolerance). A compromised HF response can't redirect the Authorization-bearing download off-domain, and a server lying about Content-Length can't exhaust the disk.
 
 MLX is **macOS/arm64 only**; `swiftlm.IsSupported()` gates both install and pull. On unsupported platforms, pulling an MLX repo exits with a clear message.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,31 +16,48 @@ Linting uses golangci-lint with `errcheck` and `unused` disabled.
 
 ## Architecture Overview
 
-**lleme** is a Go CLI for running local LLMs via llama.cpp with Hugging Face model management. Built on Charmbracelet (bubbletea, lipgloss, glamour) for TUI and Cobra for CLI.
+**lleme** is a Go CLI for running local LLMs via llama.cpp (GGUF) and SwiftLM (MLX, Apple Silicon only), with Hugging Face model management. Built on Charmbracelet (bubbletea, lipgloss, glamour) for TUI and Cobra for CLI.
 
 ### Multi-Model Proxy (Core Architecture)
 
-The central design is a reverse-proxy that manages multiple llama.cpp backend instances:
+The central design is a reverse-proxy that manages multiple backend server instances:
 
 ```
-CLI/API → Proxy (port 11313) → Routes by model name → llama-server instances (:11314+)
+CLI/API → Proxy (port 11313) → Routes by model name → backend servers (:49152+)
+                                                      ├─ llama-server (GGUF)
+                                                      └─ SwiftLM (MLX, darwin/arm64)
 ```
 
 Key packages in `internal/proxy/`:
-- `server.go` - HTTP routing, reverse-proxy to backends
-- `manager.go` - Model lifecycle (start/stop llama-server, LRU eviction, max 3 models)
+- `server.go` - HTTP routing, reverse-proxy to backends, `/v1/chat/completions` pass-through
+- `anthropic.go` - In-proxy translation of `/v1/messages` ⇄ `/v1/chat/completions` so backends only need an OpenAI surface
+- `manager.go` - Model lifecycle (start/stop backend, LRU eviction, max 3 models)
+- `backend.go` - `Runtime` interface: `Kind`, `HFAppName`, `BinaryPath`, `WorkingDir`, `BuildArgs`, `HealthURL`, `IsStartupError`
+- `backend_llama.go`, `backend_swiftlm.go` - Concrete runtimes
+- `backend_select.go` - Reads `metadata.yaml` backend kind → picks the runtime
+- `registry.go` - `AllRuntimes` / `HFAppNames` (single registration point for a new backend)
 - `idle.go` - Background monitor for auto-unloading idle models
 - `ports.go` - Dynamic port allocation for backends
+
+### Backends
+
+Each backend is a `Runtime` that owns its binary, args, health probe, and error log scan. Adding a new backend means (1) implement `Runtime`, (2) add its constructor to `AllRuntimes()` in `registry.go`, (3) add a `case` in `selectRuntime` for its `metadata.yaml` kind, (4) optionally a config section under a new YAML key to mirror `llamacpp:` / `swiftlm:`. Nothing in `cmd/` or the discovery surface hardcodes a backend list — `cmd/search.go` joins every registered `HFAppName` for the `?apps=` filter.
+
+**Security-sensitive install code is shared**: `internal/binaryrelease/` owns URL host/scheme allow-lists, download size caps, atomic symlink swap (`swiftlm-current` / `llama-current`), and a validating tar extractor (no path traversal, no escaping symlinks). Each backend installer (`internal/llama/binary.go`, `internal/swiftlm/binary.go`) wraps these primitives with its own repo URL, platform matrix, and `version.json` sibling file.
+
+MLX is **macOS/arm64 only**; `swiftlm.IsSupported()` gates both install and pull. On unsupported platforms, pulling an MLX repo exits with a clear message.
 
 ### Package Structure
 
 - `cmd/` - Cobra CLI commands (run, pull, list, serve, status, etc.)
+- `internal/binaryrelease/` - Shared GitHub-release installer primitives (download, URL allow-list, tar extraction, symlink swap)
 - `internal/config/` - Config loading/saving, personas (user-saved model settings)
-- `internal/hf/` - Hugging Face API client, model downloads, quantization detection
+- `internal/hf/` - Hugging Face API client, model downloads, GGUF + MLX detection, `inventory.go` metadata-driven listing
 - `internal/llama/` - llama.cpp binary management
+- `internal/swiftlm/` - SwiftLM binary management (MLX runtime)
 - `internal/options/` - Settings resolver with layered precedence
 - `internal/presets/` - Built-in curated sampling defaults per model family (embedded YAML)
-- `internal/proxy/` - Multi-model proxy server
+- `internal/proxy/` - Multi-model proxy server + runtime registry + Anthropic translation
 - `internal/server/` - Backend API client (OpenAI-compatible)
 - `internal/tui/` - Bubbletea TUI (chat model, components, styles)
 - `internal/ui/` - CLI utilities (spinner, progress, table, logger)
@@ -48,10 +65,13 @@ Key packages in `internal/proxy/`:
 ### Data Storage
 
 All data lives in `~/.lleme/`:
-- `config.yaml` - User configuration
-- `models/` - Downloaded GGUF files (`user/repo/quant.gguf`)
-- `bin/` - llama.cpp binaries
-- `logs/` - Rotating log files
+- `config.yaml` - User configuration (`llamacpp:` and `swiftlm:` sections)
+- `models/user/repo/metadata.yaml` - Per-repo record of each quant's backend kind; `lleme list`/`remove` walk these, not `*.gguf` globs
+- `models/user/repo/<quant>.gguf` - Single-file GGUF layout
+- `models/user/repo/<quant>/` - Directory layout (GGUF split shards OR full MLX tree with safetensors + tokenizer files)
+- `bin/llama-current/` - Active llama.cpp symlink; `bin/version.json` tracks installed tag
+- `bin/swiftlm-current/` - Active SwiftLM symlink; `bin/swiftlm-version.json` tracks installed tag
+- `logs/` - Rotating log files (one per loaded model)
 
 ### Settings Resolver & Presets
 
@@ -70,6 +90,8 @@ The resolver uses **key-existence semantics**: a key with value `0` is distinct 
 **Presets** live in `internal/presets/data/*.yaml`, embedded via `go:embed`. Each file defines sampling defaults for a model family and a list of `path.Match` globs against `user/repo`. Matching is case-insensitive and first-match-wins in **alphabetical order** of filename, so more specific files must sort before more general ones (e.g. `qwen3-coder.yaml` before `qwen3.yaml`).
 
 When adding or editing a preset, read `internal/presets/data/README.md` first — it documents pattern conventions, ordering rules, what belongs under `options` (sampling params only, no runtime/hardware knobs), and when to split a family into multiple files. The `presets_test.go` table should include a realistic HF repo name per new preset, plus an ordering test if the preset could be masked by a more general one.
+
+**Backend-specific preset/persona options**: both presets and personas support optional `llamacpp:` / `swiftlm:` sub-blocks that layer on top of the shared `options:` map for the matching runtime only. Merge order for a given backend kind: preset-shared → preset-backend → persona-shared → persona-backend (later wins). The client resolves kind via `hf.BackendKindForModelName` before calling `Persona.GetServerOptions(kind)` and `presets.MergeServerOptions(preset, personaOpts, kind)`.
 
 ## Code Patterns
 

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/nchapman/lleme/internal/hf"
+	"github.com/nchapman/lleme/internal/llama"
+	"github.com/nchapman/lleme/internal/swiftlm"
+	"github.com/nchapman/lleme/internal/ui"
+)
+
+// neededBackends describes which backend binaries must be present for the
+// caller to operate. Emptiness means "nothing to install for this invocation"
+// — callers should avoid dragging in a baseline llama download just to host
+// an MLX-only workload.
+type neededBackends struct {
+	Llama   bool
+	SwiftLM bool
+}
+
+// backendsForLocalModels inspects pulled models and reports which backend
+// binaries are required to serve them. A nil/empty inventory returns
+// {Llama: true} so a fresh install still gets the baseline runtime that
+// handles the common case (GGUF models pulled shortly after).
+//
+// Errors from the inventory read are treated as best-effort: we fall back
+// to {Llama: true, SwiftLM: IsSupported()} to avoid turning a transient
+// filesystem hiccup into a startup failure.
+func backendsForLocalModels() neededBackends {
+	models, err := hf.ListLocalModels()
+	if err != nil {
+		return neededBackends{Llama: true, SwiftLM: swiftlm.IsSupported()}
+	}
+	return decideBackendsFromInventory(models)
+}
+
+// decideBackendsFromInventory is the pure-data core of backendsForLocalModels,
+// split out for testing. Nothing here touches the filesystem or probes
+// platform support — callers layer both in.
+func decideBackendsFromInventory(models []hf.LocalModel) neededBackends {
+	if len(models) == 0 {
+		return neededBackends{Llama: true}
+	}
+
+	var need neededBackends
+	for _, m := range models {
+		switch m.Backend {
+		case hf.BackendMLX:
+			need.SwiftLM = true
+		case hf.BackendGGUF:
+			need.Llama = true
+		default:
+			need.Llama = true
+		}
+	}
+	return need
+}
+
+// ensureBackends installs the backends described by `need`, skipping any
+// that are already installed or unsupported on the current platform. An
+// MLX model pulled on a non-Apple-Silicon host produces a warning (the
+// model is not servable) but does not fail — GGUF models on the same host
+// remain usable.
+func ensureBackends(need neededBackends) error {
+	if need.Llama && !llama.IsInstalled() {
+		if err := ensureLlamaInstalled(); err != nil {
+			return err
+		}
+	}
+	if need.SwiftLM {
+		if !swiftlm.IsSupported() {
+			fmt.Println(ui.Warning("Skipping SwiftLM install: MLX requires macOS on Apple Silicon. Any pulled MLX models will not be servable here."))
+			return nil
+		}
+		if !swiftlm.IsInstalled() {
+			if err := ensureSwiftLMInstalled(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ensureSwiftLMInstalled mirrors ensureLlamaInstalled for SwiftLM. Callers
+// must check swiftlm.IsSupported() first — this helper does not gate
+// silently because a caller that asked for SwiftLM on Linux should hear
+// about it.
+func ensureSwiftLMInstalled() error {
+	fmt.Println("Installing SwiftLM...")
+	fmt.Println()
+	if _, err := swiftlm.InstallLatest(func(msg string) { fmt.Println(msg) }); err != nil {
+		return fmt.Errorf("failed to install SwiftLM: %w", err)
+	}
+	fmt.Println()
+	return nil
+}

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/nchapman/lleme/internal/hf"
+)
+
+func TestDecideBackendsFromInventory(t *testing.T) {
+	tests := []struct {
+		name   string
+		models []hf.LocalModel
+		want   neededBackends
+	}{
+		{
+			name:   "empty inventory defaults to llama baseline",
+			models: nil,
+			want:   neededBackends{Llama: true},
+		},
+		{
+			name:   "gguf only installs llama",
+			models: []hf.LocalModel{{Backend: hf.BackendGGUF}},
+			want:   neededBackends{Llama: true},
+		},
+		{
+			name:   "mlx only installs SwiftLM",
+			models: []hf.LocalModel{{Backend: hf.BackendMLX}},
+			want:   neededBackends{SwiftLM: true},
+		},
+		{
+			name:   "mixed inventory installs both",
+			models: []hf.LocalModel{{Backend: hf.BackendGGUF}, {Backend: hf.BackendMLX}},
+			want:   neededBackends{Llama: true, SwiftLM: true},
+		},
+		{
+			name:   "unknown backend falls back to llama",
+			models: []hf.LocalModel{{Backend: "unknown"}},
+			want:   neededBackends{Llama: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decideBackendsFromInventory(tt.models)
+			if got != tt.want {
+				t.Errorf("decideBackendsFromInventory = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/nchapman/lleme/internal/config"
+	"github.com/nchapman/lleme/internal/hf"
 	"github.com/nchapman/lleme/internal/options"
 	"github.com/nchapman/lleme/internal/presets"
 	"github.com/nchapman/lleme/internal/server"
@@ -38,7 +39,7 @@ func NewChatSession(api *server.APIClient, model string, cfg *config.Config, per
 		api:      api,
 		model:    model,
 		persona:  persona,
-		resolver: options.NewResolver(persona, cfg, preset),
+		resolver: options.NewResolver(persona, cfg, preset).WithBackendKind(hf.BackendKindForModelName(model)),
 		messages: []server.ChatMessage{},
 	}
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -41,14 +41,12 @@ var listCmd = &cobra.Command{
 			AddColumn("SIZE", 10, ui.AlignRight).
 			AddColumn("LAST USED", 12, ui.AlignRight)
 
+		// m.LastUsed is already the metadata's LastUsed (with file-mtime
+		// fallback). No need to re-read metadata.yaml per row.
 		var totalSize int64
 		for _, m := range models {
-			lastUsed := hf.GetLastUsed(m.User, m.Repo, m.Quant)
-			if lastUsed.IsZero() {
-				lastUsed = m.LastUsed
-			}
 			modelRef := fmt.Sprintf("%s/%s", m.User, m.Repo)
-			table.AddRow(modelRef, m.Quant, m.Backend, ui.FormatBytes(m.Size), formatTime(lastUsed))
+			table.AddRow(modelRef, m.Quant, m.Backend, ui.FormatBytes(m.Size), formatTime(m.LastUsed))
 			totalSize += m.Size
 		}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,14 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
 	"sort"
-	"strings"
 	"time"
 
-	"github.com/nchapman/lleme/internal/config"
 	"github.com/nchapman/lleme/internal/hf"
 	"github.com/nchapman/lleme/internal/ui"
 	"github.com/spf13/cobra"
@@ -21,103 +16,7 @@ var listCmd = &cobra.Command{
 	Short:   "List downloaded models",
 	GroupID: "model",
 	Run: func(cmd *cobra.Command, args []string) {
-		modelsDir := config.ModelsPath()
-
-		var models []ModelInfo
-		var totalSize int64
-		seenSplitDirs := make(map[string]bool)
-
-		err := filepath.WalkDir(modelsDir, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return fmt.Errorf("walk %s: %w", path, err)
-			}
-
-			if d.IsDir() {
-				return nil
-			}
-
-			if filepath.Ext(d.Name()) != ".gguf" {
-				return nil
-			}
-			if hf.IsMMProjFileName(d.Name()) {
-				return nil
-			}
-
-			relPath, err := filepath.Rel(modelsDir, path)
-			if err != nil {
-				return fmt.Errorf("relative path of %s: %w", path, err)
-			}
-
-			parts := strings.Split(relPath, string(filepath.Separator))
-			if len(parts) < 3 {
-				return nil
-			}
-
-			user := parts[0]
-			repo := parts[1]
-			var quant string
-			var modelSize int64
-
-			// Check if this is a split file (in a quant subdirectory)
-			// Structure: user/repo/quant/model-00001-of-NNNNN.gguf
-			if len(parts) == 4 && hf.SplitFilePattern.MatchString(d.Name()) {
-				quant = parts[2]
-				splitDirKey := filepath.Join(user, repo, quant)
-
-				// Only add the first split file we encounter for this quant
-				if seenSplitDirs[splitDirKey] {
-					return nil
-				}
-				seenSplitDirs[splitDirKey] = true
-
-				// Calculate total size of all split files. Read errors here are
-				// non-fatal: we just report whatever sizes we could sum.
-				splitDir := filepath.Dir(path)
-				entries, readErr := os.ReadDir(splitDir)
-				if readErr != nil {
-					return fmt.Errorf("read split dir %s: %w", splitDir, readErr)
-				}
-				for _, entry := range entries {
-					if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".gguf") {
-						continue
-					}
-					if info, err := entry.Info(); err == nil {
-						modelSize += info.Size()
-					}
-				}
-			} else {
-				// Standard single-file model: user/repo/quant.gguf
-				quant = strings.TrimSuffix(d.Name(), ".gguf")
-				info, err := d.Info()
-				if err != nil {
-					return fmt.Errorf("stat %s: %w", path, err)
-				}
-				modelSize = info.Size()
-			}
-
-			lastUsed := hf.GetLastUsed(user, repo, quant)
-			if lastUsed.IsZero() {
-				info, _ := d.Info()
-				if info != nil {
-					lastUsed = info.ModTime() // Fall back to download time
-				} else {
-					lastUsed = time.Now()
-				}
-			}
-
-			models = append(models, ModelInfo{
-				User:     user,
-				Repo:     repo,
-				Quant:    quant,
-				Size:     modelSize,
-				LastUsed: lastUsed,
-			})
-
-			totalSize += modelSize
-
-			return nil
-		})
-
+		models, err := hf.ListLocalModels()
 		if err != nil {
 			ui.Fatal("Failed to list models: %v", err)
 		}
@@ -129,7 +28,7 @@ var listCmd = &cobra.Command{
 			return
 		}
 
-		// Sort by most recently used
+		// Most-recently-used first.
 		sort.Slice(models, func(i, j int) bool {
 			return models[i].LastUsed.After(models[j].LastUsed)
 		})
@@ -138,12 +37,19 @@ var listCmd = &cobra.Command{
 			Indent(0).
 			AddColumn("MODEL", 0, ui.AlignLeft).
 			AddColumn("QUANT", 0, ui.AlignLeft).
+			AddColumn("BACKEND", 0, ui.AlignLeft).
 			AddColumn("SIZE", 10, ui.AlignRight).
 			AddColumn("LAST USED", 12, ui.AlignRight)
 
+		var totalSize int64
 		for _, m := range models {
+			lastUsed := hf.GetLastUsed(m.User, m.Repo, m.Quant)
+			if lastUsed.IsZero() {
+				lastUsed = m.LastUsed
+			}
 			modelRef := fmt.Sprintf("%s/%s", m.User, m.Repo)
-			table.AddRow(modelRef, m.Quant, ui.FormatBytes(m.Size), formatTime(m.LastUsed))
+			table.AddRow(modelRef, m.Quant, m.Backend, ui.FormatBytes(m.Size), formatTime(lastUsed))
+			totalSize += m.Size
 		}
 
 		fmt.Print(table.Render())

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -59,6 +59,17 @@ Examples:
 			ui.Fatal("Failed to list files: %v", err)
 		}
 
+		switch hf.DetectFormat(files) {
+		case hf.BackendMLX:
+			pullMLX(client, user, repo, quant)
+			return
+		case "":
+			ui.PrintError("No supported model files found")
+			fmt.Printf("\nThe repository '%s/%s' does not contain GGUF files or MLX weights.\n", user, repo)
+			ui.ExitFunc(1)
+			return
+		}
+
 		quants := hf.ExtractQuantizations(files)
 		if len(quants) == 0 {
 			ui.PrintError("No GGUF files found")
@@ -121,6 +132,27 @@ Examples:
 			fmt.Printf("Pulled %s\n", modelName)
 		}
 	},
+}
+
+// pullMLX handles the MLX branch: quant is inferred from the repo name when
+// not supplied, the entire repo is downloaded into a per-quant directory,
+// and metadata.yaml is updated with backend=mlx.
+func pullMLX(client *hf.Client, user, repo, quant string) {
+	if quant == "" {
+		quant = hf.MLXQuantFromRepo(repo)
+	}
+
+	modelName := ui.Keyword(hf.FormatModelName(user, repo, quant))
+	fmt.Printf("Pulling %s (MLX)\n", modelName)
+
+	result, err := hf.PullMLXModelWithProgress(client, user, repo, quant, newProgressBar)
+	if err != nil {
+		ui.Fatal("%v", err)
+	}
+
+	fmt.Printf("Pulled %s (%s)\n",
+		hf.FormatModelName(user, repo, quant),
+		ui.FormatBytes(result.TotalSize))
 }
 
 // pullModelWithProgress wraps hf.PullModel with progress bar display.

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -162,6 +162,25 @@ func pullMLX(client *hf.Client, user, repo, quant string) {
 	}
 
 	modelName := ui.Keyword(hf.FormatModelName(user, repo, quant))
+
+	// Freshness: skip re-download when every file already matches remote
+	// size. Mirrors the GGUF CheckForUpdates branch above the switch.
+	upToDate, saveManifest, remoteFiles, err := hf.CheckForUpdatesMLX(client, user, repo, quant)
+	if err != nil {
+		ui.Fatal("%v", err)
+	}
+	if upToDate {
+		if saveManifest {
+			// Legacy pull without a manifest — persist one now so the next
+			// check is a cheap JSON compare.
+			if err := hf.SaveMLXManifest(user, repo, quant, remoteFiles); err != nil {
+				ui.Fatal("Failed to save MLX manifest: %v", err)
+			}
+		}
+		fmt.Printf("%s is already up to date\n", modelName)
+		return
+	}
+
 	fmt.Printf("Pulling %s (MLX)\n", modelName)
 
 	result, err := hf.PullMLXModelWithProgress(client, user, repo, quant, newProgressBar)

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nchapman/lleme/internal/config"
 	"github.com/nchapman/lleme/internal/hf"
+	"github.com/nchapman/lleme/internal/swiftlm"
 	"github.com/nchapman/lleme/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -138,6 +139,14 @@ Examples:
 // not supplied, the entire repo is downloaded into a per-quant directory,
 // and metadata.yaml is updated with backend=mlx.
 func pullMLX(client *hf.Client, user, repo, quant string) {
+	if !swiftlm.IsSupported() {
+		ui.PrintError("MLX models require macOS on Apple Silicon")
+		fmt.Fprintln(os.Stderr, "\nThis repository contains MLX weights, which only run under SwiftLM on darwin/arm64.")
+		fmt.Fprintln(os.Stderr, "On other platforms, pull a GGUF repo (e.g. a bartowski/* or unsloth/* release).")
+		ui.ExitFunc(1)
+		return
+	}
+
 	if quant == "" {
 		quant = hf.MLXQuantFromRepo(repo)
 	}

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -147,6 +147,16 @@ func pullMLX(client *hf.Client, user, repo, quant string) {
 		return
 	}
 
+	// Install SwiftLM now if it's missing — pulling an MLX model with no
+	// runtime to serve it would be a dead end.
+	if !swiftlm.IsInstalled() {
+		fmt.Println("Installing SwiftLM...")
+		if _, err := swiftlm.InstallLatest(func(msg string) { fmt.Println(msg) }); err != nil {
+			ui.Fatal("Failed to install SwiftLM: %v", err)
+		}
+		fmt.Println()
+	}
+
 	if quant == "" {
 		quant = hf.MLXQuantFromRepo(repo)
 	}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -139,39 +138,24 @@ Examples:
 		removed := 0
 		var freedSize int64
 		for _, m := range models {
-			// Find the actual model path (handles both single and split files)
-			modelPath := hf.FindModelFile(m.User, m.Repo, m.Quant)
-			if modelPath == "" {
-				modelPath = hf.GetModelFilePath(m.User, m.Repo, m.Quant)
+			local := hf.LocalModel{
+				User:    m.User,
+				Repo:    m.Repo,
+				Quant:   m.Quant,
+				Backend: m.Backend,
+				Path:    m.Path,
+				Size:    m.Size,
 			}
-
-			// Check if this is a split file (stored in a quant subdirectory)
-			splitDir := hf.GetSplitModelDir(m.User, m.Repo, m.Quant)
-			if info, err := os.Stat(splitDir); err == nil && info.IsDir() {
-				// Remove the entire split directory
-				if err := os.RemoveAll(splitDir); err != nil {
-					ui.PrintError("Failed to remove %s: %v", hf.FormatModelName(m.User, m.Repo, m.Quant), err)
-					continue
-				}
-			} else {
-				// Single file - remove it directly
-				if err := os.Remove(modelPath); err != nil {
-					ui.PrintError("Failed to remove %s: %v", hf.FormatModelName(m.User, m.Repo, m.Quant), err)
-					continue
-				}
+			if err := hf.RemoveLocalModel(local); err != nil {
+				ui.PrintError("Failed to remove %s: %v", hf.FormatModelName(m.User, m.Repo, m.Quant), err)
+				continue
 			}
 			freedSize += m.Size
 
-			// Also remove associated files (manifest, mmproj, metadata)
-			// These may not exist; errors are expected and safe to ignore
-			os.Remove(hf.GetManifestFilePath(m.User, m.Repo, m.Quant))
-			os.Remove(hf.GetMMProjFilePath(m.User, m.Repo, m.Quant))
-
-			// Clean up empty directories
+			// Clean up empty directories.
 			modelDir := hf.GetModelPath(m.User, m.Repo)
 			cleanEmptyDir(modelDir)
-			userDir := filepath.Dir(modelDir)
-			cleanEmptyDir(userDir)
+			cleanEmptyDir(filepath.Dir(modelDir))
 
 			removed++
 		}
@@ -185,138 +169,54 @@ Examples:
 	},
 }
 
-// findModels returns models matching the pattern and filters
+// findModels returns models matching the pattern and filters.
 func findModels(pattern string, olderThan time.Duration, largerThan int64) ([]ModelInfo, error) {
 	return findModelsInDir(config.ModelsPath(), pattern, olderThan, largerThan)
 }
 
-// findModelsInDir is the testable version of findModels
+// findModelsInDir is the testable sibling of findModels. It sources the
+// raw inventory from hf.ListLocalModelsInDir (which knows about both GGUF
+// and MLX layouts) and then applies the user-supplied glob + age/size
+// filters on top.
 func findModelsInDir(modelsDir, pattern string, olderThan time.Duration, largerThan int64) ([]ModelInfo, error) {
 	re, err := regexp.Compile("^" + globToRegex(pattern) + "$")
 	if err != nil {
 		return nil, fmt.Errorf("invalid pattern: %s", pattern)
 	}
 
-	w := &modelWalker{
-		modelsDir:  modelsDir,
-		re:         re,
-		olderThan:  olderThan,
-		largerThan: largerThan,
-		seen:       make(map[string]bool),
-	}
-
-	if err := filepath.WalkDir(modelsDir, w.walk); err != nil {
+	locals, err := hf.ListLocalModelsInDir(modelsDir)
+	if err != nil {
 		return nil, err
 	}
-	return w.models, nil
-}
 
-type modelWalker struct {
-	modelsDir  string
-	re         *regexp.Regexp
-	olderThan  time.Duration
-	largerThan int64
-	seen       map[string]bool
-	models     []ModelInfo
-}
-
-func (w *modelWalker) walk(path string, d fs.DirEntry, err error) error {
-	if err != nil {
-		return fmt.Errorf("walk %s: %w", path, err)
-	}
-	if d.IsDir() || filepath.Ext(d.Name()) != ".gguf" {
-		return nil
-	}
-
-	relPath, err := filepath.Rel(w.modelsDir, path)
-	if err != nil {
-		return fmt.Errorf("relative path of %s: %w", path, err)
-	}
-
-	parts := strings.Split(relPath, string(filepath.Separator))
-	if len(parts) < 3 {
-		return nil
-	}
-
-	user, repo := parts[0], parts[1]
-
-	quant, size, skip, err := classifyModelEntry(user, repo, parts, path, d, w.seen)
-	if err != nil {
-		return fmt.Errorf("classify %s: %w", relPath, err)
-	}
-	if skip {
-		return nil
-	}
-
-	if !w.re.MatchString(hf.FormatModelName(user, repo, quant)) && !w.re.MatchString(user+"/"+repo) {
-		return nil
-	}
-
-	lastUsed := modelLastUsed(user, repo, quant, d)
-	if !w.passesFilters(size, lastUsed) {
-		return nil
-	}
-
-	w.models = append(w.models, ModelInfo{
-		User:     user,
-		Repo:     repo,
-		Quant:    quant,
-		Size:     size,
-		LastUsed: lastUsed,
-	})
-	return nil
-}
-
-func (w *modelWalker) passesFilters(size int64, lastUsed time.Time) bool {
-	if w.olderThan > 0 && time.Since(lastUsed) < w.olderThan {
-		return false
-	}
-	if w.largerThan > 0 && size < w.largerThan {
-		return false
-	}
-	return true
-}
-
-// classifyModelEntry determines user/repo/quant/size for a .gguf file during a WalkDir.
-// Returns skip=true when the entry should be ignored (e.g. a duplicate split shard).
-func classifyModelEntry(user, repo string, parts []string, path string, d fs.DirEntry, seenSplitDirs map[string]bool) (quant string, size int64, skip bool, err error) {
-	if len(parts) == 4 && hf.SplitFilePattern.MatchString(d.Name()) {
-		quant = parts[2]
-		key := filepath.Join(user, repo, quant)
-		if seenSplitDirs[key] {
-			return "", 0, true, nil
+	var out []ModelInfo
+	for _, m := range locals {
+		fullName := hf.FormatModelName(m.User, m.Repo, m.Quant)
+		repoName := m.User + "/" + m.Repo
+		if !re.MatchString(fullName) && !re.MatchString(repoName) {
+			continue
 		}
-		seenSplitDirs[key] = true
-
-		entries, _ := os.ReadDir(filepath.Dir(path))
-		for _, entry := range entries {
-			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".gguf") {
-				continue
-			}
-			if info, infoErr := entry.Info(); infoErr == nil {
-				size += info.Size()
-			}
+		lastUsed := m.LastUsed
+		if t := hf.GetLastUsed(m.User, m.Repo, m.Quant); !t.IsZero() {
+			lastUsed = t
 		}
-		return quant, size, false, nil
+		if olderThan > 0 && time.Since(lastUsed) < olderThan {
+			continue
+		}
+		if largerThan > 0 && m.Size < largerThan {
+			continue
+		}
+		out = append(out, ModelInfo{
+			User:     m.User,
+			Repo:     m.Repo,
+			Quant:    m.Quant,
+			Backend:  m.Backend,
+			Path:     m.Path,
+			Size:     m.Size,
+			LastUsed: lastUsed,
+		})
 	}
-
-	quant = strings.TrimSuffix(d.Name(), ".gguf")
-	info, err := d.Info()
-	if err != nil {
-		return "", 0, false, err
-	}
-	return quant, info.Size(), false, nil
-}
-
-// modelLastUsed returns the last-used time for a model, falling back to mtime.
-func modelLastUsed(user, repo, quant string, d fs.DirEntry) time.Time {
-	if t := hf.GetLastUsed(user, repo, quant); !t.IsZero() {
-		return t
-	}
-	if info, err := d.Info(); err == nil {
-		return info.ModTime()
-	}
-	return time.Now()
+	return out, nil
 }
 
 // globToRegex converts a glob pattern to a regex pattern

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -196,11 +196,7 @@ func findModelsInDir(modelsDir, pattern string, olderThan time.Duration, largerT
 		if !re.MatchString(fullName) && !re.MatchString(repoName) {
 			continue
 		}
-		lastUsed := m.LastUsed
-		if t := hf.GetLastUsed(m.User, m.Repo, m.Quant); !t.IsZero() {
-			lastUsed = t
-		}
-		if olderThan > 0 && time.Since(lastUsed) < olderThan {
+		if olderThan > 0 && time.Since(m.LastUsed) < olderThan {
 			continue
 		}
 		if largerThan > 0 && m.Size < largerThan {
@@ -213,7 +209,7 @@ func findModelsInDir(modelsDir, pattern string, olderThan time.Duration, largerT
 			Backend:  m.Backend,
 			Path:     m.Path,
 			Size:     m.Size,
-			LastUsed: lastUsed,
+			LastUsed: m.LastUsed,
 		})
 	}
 	return out, nil

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,6 +38,11 @@ var (
 	ctxSize   int
 	gpuLayers int
 	threads   int
+
+	// SwiftLM boolean toggles (ignored by llama.cpp backends with a warning)
+	thinkingFlag bool
+	visionFlag   bool
+	audioFlag    bool
 )
 
 var runCmd = &cobra.Command{
@@ -188,6 +193,7 @@ Models are loaded on-demand and unloaded after idle timeout.`,
 				personaOpts = activePersona.GetServerOptions(backendKind)
 			}
 			mergedOpts := presets.MergeServerOptions(activePreset, personaOpts, backendKind)
+			mergedOpts = mergeSessionToggles(cmd, backendKind, mergedOpts)
 			if ctxSizeSet || gpuLayersSet || threadsSet || mergedOpts != nil {
 				opts := &server.RunOptions{
 					Options: mergedOpts,
@@ -220,6 +226,12 @@ Models are loaded on-demand and unloaded after idle timeout.`,
 		m.SetInitialServerOptions(ctxSize, gpuLayers, threads, ctxSizeSet, gpuLayersSet, threadsSet)
 		m.SetSamplingOptions(temperature, topP, minP, repeatPenalty, presencePenalty, frequencyPenalty, topK, tokens)
 		m.SetSystemPrompt(systemPrompt)
+		// The MLX-kind check in the TUI helper drops mismatched toggles
+		// silently (warning mid-render corrupts the screen). Users get
+		// the warning on the one-shot path.
+		if toggles := collectSessionToggles(cmd); toggles != nil {
+			m.SetSessionToggles(toggles)
+		}
 
 		p := tea.NewProgram(m, tea.WithAltScreen())
 		m.SetProgram(p)
@@ -228,6 +240,59 @@ Models are loaded on-demand and unloaded after idle timeout.`,
 			ui.Fatal("TUI error: %v", err)
 		}
 	},
+}
+
+// mergeSessionToggles overlays CLI toggles onto mergedOpts. Toggles that
+// belong to a different backend (e.g. --thinking on a GGUF model) warn once
+// and are dropped so cross-backend personas work without the user editing
+// YAML between runs.
+func mergeSessionToggles(cmd *cobra.Command, backendKind string, mergedOpts map[string]any) map[string]any {
+	for _, t := range sessionToggleFlags() {
+		if !cmd.Flags().Changed(t.flag) {
+			continue
+		}
+		if backendKind != hf.BackendMLX {
+			fmt.Println(ui.Warning(fmt.Sprintf("--%s has no effect on llama.cpp backends; ignoring.", t.flag)))
+			continue
+		}
+		if mergedOpts == nil {
+			mergedOpts = make(map[string]any)
+		}
+		mergedOpts[t.flag] = t.value
+	}
+	return mergedOpts
+}
+
+// collectSessionToggles returns the CLI toggles the user explicitly set,
+// keyed by flag name. Returns nil when nothing was set so callers can skip
+// the TUI setter entirely. Unlike mergeSessionToggles, this does not warn
+// — the TUI path doesn't know the backend kind until preloadModel runs.
+func collectSessionToggles(cmd *cobra.Command) map[string]any {
+	var out map[string]any
+	for _, t := range sessionToggleFlags() {
+		if !cmd.Flags().Changed(t.flag) {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]any)
+		}
+		out[t.flag] = t.value
+	}
+	return out
+}
+
+func sessionToggleFlags() []struct {
+	flag  string
+	value bool
+} {
+	return []struct {
+		flag  string
+		value bool
+	}{
+		{"thinking", thinkingFlag},
+		{"vision", visionFlag},
+		{"audio", audioFlag},
+	}
 }
 
 // ensureLlamaInstalled installs llama.cpp if not present
@@ -489,4 +554,11 @@ func init() {
 	runCmd.Flags().IntVar(&ctxSize, "ctx-size", 0, "Context size (0 = model default)")
 	runCmd.Flags().IntVar(&gpuLayers, "gpu-layers", 0, "GPU layers to offload (0 = auto)")
 	runCmd.Flags().IntVar(&threads, "threads", 0, "CPU threads (0 = auto)")
+
+	// SwiftLM-specific toggles. These are safe to leave on a persona or preset
+	// shared between backends; on llama.cpp they emit a one-line warning and
+	// are ignored.
+	runCmd.Flags().BoolVar(&thinkingFlag, "thinking", false, "Enable reasoning mode (SwiftLM only)")
+	runCmd.Flags().BoolVar(&visionFlag, "vision", false, "Enable vision input (SwiftLM only)")
+	runCmd.Flags().BoolVar(&audioFlag, "audio", false, "Enable audio input (SwiftLM only)")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -169,9 +169,9 @@ Models are loaded on-demand and unloaded after idle timeout.`,
 		// One-shot mode for CLI prompts or piped input
 		if promptArg != "" {
 			// Resolve the backend kind so preset/persona backend-specific
-			// sections land in the right runtime. Errors here only mean
-			// we'll use shared options, which is the safe default.
-			backendKind, _ := hf.GetBackendKind(resolvedModel.User, resolvedModel.Repo, resolvedModel.Quant)
+			// sections land in the right runtime. Errors fall back to
+			// gguf inside the helper, which is the safe default.
+			backendKind := hf.BackendKindForModelName(modelName)
 
 			// Preload model with options (sync - user is blocked waiting for output anyway)
 			var personaOpts map[string]any

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -64,12 +64,9 @@ Models are loaded on-demand and unloaded after idle timeout.`,
 			ui.Fatal("Failed to load config: %v", err)
 		}
 
-		// Step 1: Ensure llama.cpp is installed
-		if !llama.IsInstalled() {
-			if err := ensureLlamaInstalled(); err != nil {
-				ui.Fatal("%v", err)
-			}
-		}
+		// Backend install is deferred until after model resolution so we
+		// only download the runtime we actually need (GGUF → llama.cpp,
+		// MLX → SwiftLM). See Step 2 below.
 
 		modelQuery := args[0]
 		promptStartIdx := 1 // Where prompt args begin (shifts if persona has no model)
@@ -107,6 +104,18 @@ Models are loaded on-demand and unloaded after idle timeout.`,
 		// Step 2: Validate model exists (or offer to pull)
 		resolvedModel, err := validateModel(modelQuery, cfg)
 		if err != nil {
+			ui.Fatal("%v", err)
+		}
+
+		// Install the backend this specific model needs. validateModel may
+		// have just pulled it, so metadata is fresh and BackendKindForModelName
+		// returns the right kind.
+		kind := hf.BackendKindForModelName(resolvedModel.FullName)
+		need := neededBackends{
+			Llama:   kind == hf.BackendGGUF,
+			SwiftLM: kind == hf.BackendMLX,
+		}
+		if err := ensureBackends(need); err != nil {
 			ui.Fatal("%v", err)
 		}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -168,12 +168,17 @@ Models are loaded on-demand and unloaded after idle timeout.`,
 
 		// One-shot mode for CLI prompts or piped input
 		if promptArg != "" {
+			// Resolve the backend kind so preset/persona backend-specific
+			// sections land in the right runtime. Errors here only mean
+			// we'll use shared options, which is the safe default.
+			backendKind, _ := hf.GetBackendKind(resolvedModel.User, resolvedModel.Repo, resolvedModel.Quant)
+
 			// Preload model with options (sync - user is blocked waiting for output anyway)
 			var personaOpts map[string]any
 			if activePersona != nil {
-				personaOpts = activePersona.GetServerOptions()
+				personaOpts = activePersona.GetServerOptions(backendKind)
 			}
-			mergedOpts := presets.MergeServerOptions(activePreset, personaOpts)
+			mergedOpts := presets.MergeServerOptions(activePreset, personaOpts, backendKind)
 			if ctxSizeSet || gpuLayersSet || threadsSet || mergedOpts != nil {
 				opts := &server.RunOptions{
 					Options: mergedOpts,

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/nchapman/lleme/internal/config"
 	"github.com/nchapman/lleme/internal/hf"
@@ -12,9 +13,9 @@ import (
 
 var searchCmd = &cobra.Command{
 	Use:     "search [query]",
-	Short:   "Search Hugging Face for GGUF models",
+	Short:   "Search Hugging Face for compatible models",
 	GroupID: "discovery",
-	Long:    "Search Hugging Face for GGUF models. If no query is provided, shows trending models.",
+	Long:    "Search Hugging Face for models compatible with any registered backend (GGUF and MLX today). If no query is provided, shows trending models.",
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg, err := config.Load()
@@ -28,7 +29,8 @@ var searchCmd = &cobra.Command{
 			query = args[0]
 		}
 
-		results, err := client.SearchModels(query, 20)
+		apps := proxy.HFAppNames()
+		results, err := client.SearchModels(query, 20, apps)
 		if err != nil {
 			ui.Fatal("Failed to search: %v", err)
 		}
@@ -43,7 +45,7 @@ var searchCmd = &cobra.Command{
 			fmt.Println("Tips:")
 			fmt.Println("  Try a different search term")
 			fmt.Println("  Check spelling")
-			fmt.Println("  Browse Hugging Face: https://huggingface.co/models?apps=llama.cpp")
+			fmt.Printf("  Browse Hugging Face: https://huggingface.co/models?apps=%s&sort=trending\n", strings.Join(apps, ","))
 			return
 		}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -68,13 +68,8 @@ Use --host, --port, and --max-models to override the values from config.`,
 		if err := validateServerFlags(); err != nil {
 			ui.Fatal("%v", err)
 		}
-		if !llama.IsInstalled() {
-			fmt.Println("Installing llama.cpp...")
-			fmt.Println()
-			if _, err := llama.InstallLatest(func(msg string) { fmt.Println(msg) }); err != nil {
-				ui.Fatal("Failed to install llama.cpp: %v", err)
-			}
-			fmt.Println()
+		if err := ensureBackends(backendsForLocalModels()); err != nil {
+			ui.Fatal("%v", err)
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/nchapman/lleme/internal/config"
-	"github.com/nchapman/lleme/internal/llama"
 	"github.com/nchapman/lleme/internal/logs"
 	"github.com/nchapman/lleme/internal/proxy"
 	"github.com/nchapman/lleme/internal/ui"
@@ -282,9 +281,8 @@ func startServerForeground() {
 	fmt.Printf("  %-12s %s %s\n", "Status", ui.Muted("GET"), "/api/status")
 	fmt.Println()
 
-	installed, _ := llama.GetInstalledVersion()
-	if installed != nil {
-		fmt.Println(ui.LlamaCppCredit(installed.TagName))
+	if credit := ui.BackendsCredit(installedBackendTags()); credit != "" {
+		fmt.Println(credit)
 	}
 	fmt.Println(ui.Muted("Press Ctrl+C to stop"))
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/nchapman/lleme/internal/llama"
 	"github.com/nchapman/lleme/internal/proxy"
+	"github.com/nchapman/lleme/internal/swiftlm"
 	"github.com/nchapman/lleme/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -86,13 +87,29 @@ var statusCmd = &cobra.Command{
 		if len(status.Models) != 1 {
 			modelWord = "models"
 		}
-		installed, _ := llama.GetInstalledVersion()
-		if installed != nil {
-			fmt.Printf("%d %s loaded %s %s\n", len(status.Models), modelWord, ui.Muted("•"), ui.LlamaCppCredit(installed.TagName))
+		credit := ui.BackendsCredit(installedBackendTags())
+		if credit != "" {
+			fmt.Printf("%d %s loaded %s %s\n", len(status.Models), modelWord, ui.Muted("•"), credit)
 		} else {
 			fmt.Printf("%d %s loaded\n", len(status.Models), modelWord)
 		}
 	},
+}
+
+// installedBackendTags returns the installed tags for each backend that has
+// a version file on disk, or "" for backends that aren't installed. On
+// unsupported platforms SwiftLM is always "". Callers hand both into
+// ui.BackendsCredit which joins the non-empty set.
+func installedBackendTags() (llamaTag, swiftTag string) {
+	if installed, _ := llama.GetInstalledVersion(); installed != nil {
+		llamaTag = installed.TagName
+	}
+	if swiftlm.IsSupported() {
+		if installed, _ := swiftlm.GetInstalledVersion(); installed != nil {
+			swiftTag = installed.TagName
+		}
+	}
+	return llamaTag, swiftTag
 }
 
 func getProxyStatus(proxyURL string) (*proxy.ProxyStatus, error) {

--- a/cmd/trending.go
+++ b/cmd/trending.go
@@ -6,7 +6,7 @@ import (
 
 var trendingCmd = &cobra.Command{
 	Use:     "trending",
-	Short:   "Show trending GGUF models on Hugging Face",
+	Short:   "Show trending models on Hugging Face",
 	GroupID: "discovery",
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -2,11 +2,15 @@ package cmd
 
 import "time"
 
-// ModelInfo represents a locally downloaded model.
+// ModelInfo represents a locally downloaded model. Backend / Path mirror
+// hf.LocalModel so cmd code can delete by the inventory's authoritative
+// answer rather than re-deriving paths per backend.
 type ModelInfo struct {
 	User     string
 	Repo     string
 	Quant    string
+	Backend  string
+	Path     string
 	Size     int64
 	LastUsed time.Time
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -6,13 +6,14 @@ import (
 	"github.com/nchapman/lleme/internal/llama"
 	"github.com/nchapman/lleme/internal/proxy"
 	"github.com/nchapman/lleme/internal/selfupdate"
+	"github.com/nchapman/lleme/internal/swiftlm"
 	"github.com/nchapman/lleme/internal/ui"
 	"github.com/spf13/cobra"
 )
 
 var updateCmd = &cobra.Command{
 	Use:     "update",
-	Short:   "Update lleme and/or llama.cpp",
+	Short:   "Update lleme and/or backend runtimes",
 	GroupID: "config",
 	Run:     runUpdateAll,
 }
@@ -21,6 +22,12 @@ var updateLlamaCmd = &cobra.Command{
 	Use:   "llama.cpp",
 	Short: "Update llama.cpp to the latest version",
 	Run:   runUpdateLlama,
+}
+
+var updateSwiftLMCmd = &cobra.Command{
+	Use:   "swiftlm",
+	Short: "Update SwiftLM to the latest version (macOS Apple Silicon only)",
+	Run:   runUpdateSwiftLM,
 }
 
 var updateSelfCmd = &cobra.Command{
@@ -36,6 +43,7 @@ func init() {
 
 	rootCmd.AddCommand(updateCmd)
 	updateCmd.AddCommand(updateLlamaCmd)
+	updateCmd.AddCommand(updateSwiftLMCmd)
 	updateCmd.AddCommand(updateSelfCmd)
 }
 
@@ -43,70 +51,138 @@ func runUpdateAll(cmd *cobra.Command, args []string) {
 	fmt.Println("Checking for updates...")
 	fmt.Println()
 
-	// Check lleme version
-	llemeInstalled := selfupdate.GetInstalledVersion()
-	llemeLatest, llemeErr := selfupdate.GetLatestVersion()
-	llemeNeedsUpdate := llemeErr == nil && llemeInstalled != llemeLatest
+	checks := collectUpdateChecks()
+	renderUpdateChecks(checks)
 
-	// Check llama.cpp version
-	llamaInstalled, llamaErr := llama.GetInstalledVersion()
-	llamaRelease, llamaFetchErr := llama.GetLatestVersion()
-
-	llamaInstalledStr := "Not installed"
-	if llamaInstalled != nil {
-		llamaInstalledStr = llamaInstalled.TagName
+	var updates []string
+	for _, c := range checks {
+		if c.needsUpdate {
+			updates = append(updates, fmt.Sprintf("%s to %s", c.name, c.latestStr))
+		}
 	}
-
-	llamaLatestStr := "Unknown"
-	if llamaRelease != nil {
-		llamaLatestStr = llamaRelease.TagName
-	}
-
-	llamaNeedsUpdate := llamaUpdateAvailable(llamaInstalled, llamaRelease, llamaFetchErr)
-
-	// Display status
-	printComponentStatus("lleme", llemeInstalled, llemeLatest, llemeErr, llemeNeedsUpdate)
-	printComponentStatus("llama.cpp", llamaInstalledStr, llamaLatestStr, llamaFetchErr, llamaNeedsUpdate)
-
-	if llamaErr != nil {
-		ui.PrintError("Failed to check llama.cpp installed version: %v", llamaErr)
-	}
-
-	if !llemeNeedsUpdate && !llamaNeedsUpdate {
+	if len(updates) == 0 {
 		fmt.Println("Everything is up to date")
 		return
 	}
 
-	// Build update message
-	var updates []string
-	if llemeNeedsUpdate {
-		updates = append(updates, fmt.Sprintf("lleme to %s", llemeLatest))
-	}
-	if llamaNeedsUpdate {
-		updates = append(updates, fmt.Sprintf("llama.cpp to %s", llamaLatestStr))
-	}
-
 	if !forceUpdate {
-		prompt := fmt.Sprintf("Update %s?", joinWithAnd(updates))
-		if !ui.PromptYesNo(prompt, false) {
+		if !ui.PromptYesNo(fmt.Sprintf("Update %s?", joinWithAnd(updates)), false) {
 			fmt.Println(ui.Muted("Cancelled"))
 			return
 		}
 	}
 	fmt.Println()
 
-	// Update lleme if needed
-	if llemeNeedsUpdate {
-		updateLleme(selfupdate.DetectInstallMethod())
+	for _, c := range checks {
+		if !c.needsUpdate {
+			continue
+		}
+		c.apply()
 		fmt.Println()
 	}
 
-	// Update llama.cpp if needed
-	if llamaNeedsUpdate {
-		updateLlamaCpp()
-	}
-
 	restartServerIfRunning()
+}
+
+// updateCheck bundles everything runUpdateAll needs about one component
+// (lleme / llama.cpp / SwiftLM) in a single shape, so the main flow stays
+// declarative and doesn't branch per component.
+type updateCheck struct {
+	name         string
+	installedStr string
+	latestStr    string
+	fetchErr     error
+	readErr      error // surfaced after status rendering
+	needsUpdate  bool
+	skipStatus   bool   // SwiftLM on unsupported platforms
+	readErrLabel string // what to say when readErr != nil
+	apply        func()
+}
+
+func collectUpdateChecks() []updateCheck {
+	return []updateCheck{
+		checkLlemeUpdate(),
+		checkLlamaCppUpdate(),
+		checkSwiftLMUpdate(),
+	}
+}
+
+func renderUpdateChecks(checks []updateCheck) {
+	for _, c := range checks {
+		if c.skipStatus {
+			continue
+		}
+		printComponentStatus(c.name, c.installedStr, c.latestStr, c.fetchErr, c.needsUpdate)
+	}
+	for _, c := range checks {
+		if c.readErr != nil && c.readErrLabel != "" {
+			ui.PrintError("%s: %v", c.readErrLabel, c.readErr)
+		}
+	}
+}
+
+func checkLlemeUpdate() updateCheck {
+	installed := selfupdate.GetInstalledVersion()
+	latest, err := selfupdate.GetLatestVersion()
+	needs := err == nil && installed != latest
+	return updateCheck{
+		name:         "lleme",
+		installedStr: installed,
+		latestStr:    latest,
+		fetchErr:     err,
+		needsUpdate:  needs,
+		apply:        func() { updateLleme(selfupdate.DetectInstallMethod()) },
+	}
+}
+
+func checkLlamaCppUpdate() updateCheck {
+	installed, readErr := llama.GetInstalledVersion()
+	release, fetchErr := llama.GetLatestVersion()
+	installedStr := "Not installed"
+	if installed != nil {
+		installedStr = installed.TagName
+	}
+	latestStr := "Unknown"
+	if release != nil {
+		latestStr = release.TagName
+	}
+	return updateCheck{
+		name:         "llama.cpp",
+		installedStr: installedStr,
+		latestStr:    latestStr,
+		fetchErr:     fetchErr,
+		readErr:      readErr,
+		readErrLabel: "Failed to check llama.cpp installed version",
+		needsUpdate:  llamaUpdateAvailable(installed, release, fetchErr),
+		apply:        updateLlamaCpp,
+	}
+}
+
+func checkSwiftLMUpdate() updateCheck {
+	if !swiftlm.IsSupported() {
+		return updateCheck{name: "SwiftLM", skipStatus: true}
+	}
+	installed, readErr := swiftlm.GetInstalledVersion()
+	release, fetchErr := swiftlm.GetLatestVersion()
+	installedStr := "Not installed"
+	if installed != nil {
+		installedStr = installed.TagName
+	}
+	latestStr := "Unknown"
+	if release != nil {
+		latestStr = release.TagName
+	}
+	needs := fetchErr == nil && release != nil && (installed == nil || installed.TagName != release.TagName)
+	return updateCheck{
+		name:         "SwiftLM",
+		installedStr: installedStr,
+		latestStr:    latestStr,
+		fetchErr:     fetchErr,
+		readErr:      readErr,
+		readErrLabel: "Failed to check SwiftLM installed version",
+		needsUpdate:  needs,
+		apply:        updateSwiftLM,
+	}
 }
 
 func llamaUpdateAvailable(installed *llama.VersionInfo, latest *llama.Release, fetchErr error) bool {
@@ -169,6 +245,49 @@ func runUpdateLlama(cmd *cobra.Command, args []string) {
 	restartServerIfRunning()
 }
 
+func runUpdateSwiftLM(cmd *cobra.Command, args []string) {
+	if !swiftlm.IsSupported() {
+		ui.Fatal("SwiftLM (MLX) requires macOS on Apple Silicon")
+	}
+	fmt.Println("Checking for SwiftLM updates...")
+	fmt.Println()
+
+	installed, err := swiftlm.GetInstalledVersion()
+	if err != nil {
+		ui.Fatal("Failed to check installed version: %v", err)
+	}
+
+	release, err := swiftlm.GetLatestVersion()
+	if err != nil {
+		ui.Fatal("Failed to get latest release: %v", err)
+	}
+
+	currentVersion := "Not installed"
+	if installed != nil {
+		currentVersion = installed.TagName
+	}
+
+	fmt.Printf("  %-12s %s\n", "Installed", currentVersion)
+	fmt.Printf("  %-12s %s\n", "Available", release.TagName)
+	fmt.Println()
+
+	if installed != nil && installed.TagName == release.TagName {
+		fmt.Println("SwiftLM is already up to date")
+		return
+	}
+
+	if !forceUpdate {
+		if !ui.PromptYesNo(fmt.Sprintf("Update to %s?", release.TagName), false) {
+			fmt.Println(ui.Muted("Cancelled"))
+			return
+		}
+	}
+
+	fmt.Println()
+	updateSwiftLM()
+	restartServerIfRunning()
+}
+
 func runUpdateSelf(cmd *cobra.Command, args []string) {
 	fmt.Println("Checking for lleme updates...")
 	fmt.Println()
@@ -225,6 +344,14 @@ func updateLlamaCpp() {
 		ui.Fatal("Failed to install llama.cpp: %v", err)
 	}
 	fmt.Printf("Updated to llama.cpp %s\n", version.TagName)
+}
+
+func updateSwiftLM() {
+	version, err := swiftlm.InstallLatest(func(msg string) { fmt.Println(msg) })
+	if err != nil {
+		ui.Fatal("Failed to install SwiftLM: %v", err)
+	}
+	fmt.Printf("Updated to SwiftLM %s\n", version.TagName)
 }
 
 func joinWithAnd(items []string) string {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nchapman/lleme/internal/config"
 	"github.com/nchapman/lleme/internal/llama"
+	"github.com/nchapman/lleme/internal/swiftlm"
 	"github.com/nchapman/lleme/internal/ui"
 	"github.com/nchapman/lleme/internal/version"
 	"github.com/spf13/cobra"
@@ -27,6 +28,18 @@ var versionCmd = &cobra.Command{
 			fmt.Printf("%s (%s)\n", ui.LlamaCppCredit(installed.TagName), backend)
 		} else {
 			fmt.Println(ui.Muted("llama.cpp not installed"))
+		}
+
+		// SwiftLM line only appears on supported platforms. On Linux we
+		// skip entirely rather than printing "SwiftLM not installed" on
+		// hosts where it could never be.
+		if swiftlm.IsSupported() {
+			swiftInstalled, _ := swiftlm.GetInstalledVersion()
+			if swiftInstalled != nil {
+				fmt.Println(ui.SwiftLMCredit(swiftInstalled.TagName))
+			} else {
+				fmt.Println(ui.Muted("SwiftLM not installed"))
+			}
 		}
 
 		fmt.Println()

--- a/internal/binaryrelease/binaryrelease.go
+++ b/internal/binaryrelease/binaryrelease.go
@@ -277,26 +277,27 @@ func ExtractTarGz(archivePath, destDir string) error {
 	}
 }
 
-// safeJoin returns absDest/rel, guaranteed to live under absDest. Rejects
-// absolute entry names, .. traversal, and any path that lexically or via
-// symlink resolution escapes absDest.
-func safeJoin(absDest, name string) (string, error) {
+// SafeJoin returns absDest/rel, guaranteed to live under absDest. Rejects
+// absolute entry names, .. traversal, and any path that lexically escapes
+// absDest. Used by ExtractTarGz and by callers (e.g. hf.PullMLXModel) that
+// need to join an attacker-influenced relative path onto a local root.
+func SafeJoin(absDest, name string) (string, error) {
 	clean := filepath.Clean(name)
 	if filepath.IsAbs(clean) {
-		return "", fmt.Errorf("archive entry %q has absolute path", name)
+		return "", fmt.Errorf("path %q is absolute", name)
 	}
 	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("archive entry %q escapes destination", name)
+		return "", fmt.Errorf("path %q escapes destination", name)
 	}
 	joined := filepath.Join(absDest, clean)
 	if joined != absDest && !strings.HasPrefix(joined, absDest+string(filepath.Separator)) {
-		return "", fmt.Errorf("archive entry %q escapes destination", name)
+		return "", fmt.Errorf("path %q escapes destination", name)
 	}
 	return joined, nil
 }
 
 func extractEntry(tr *tar.Reader, hdr *tar.Header, absDest string) error {
-	target, err := safeJoin(absDest, hdr.Name)
+	target, err := SafeJoin(absDest, hdr.Name)
 	if err != nil {
 		return err
 	}
@@ -327,13 +328,22 @@ func writeTarFile(tr *tar.Reader, hdr *tar.Header, target string, mode os.FileMo
 	}
 	// Cap the per-entry copy so an inflated gzip bomb can't fill disk.
 	// hdr.Size<=0 means "unknown/empty"; clamp to a generous 8 GiB ceiling.
+	// Use LimitReader(limit+1)+io.Copy so a source that exactly matches the
+	// cap — and has leftover bytes that would bleed into the next tar entry
+	// — is rejected. io.CopyN can't distinguish "source ended at limit" from
+	// "source has more than limit," which would corrupt subsequent files.
 	limit := hdr.Size
 	if limit <= 0 || limit > 1<<33 {
 		limit = 1 << 33
 	}
-	if _, err := io.CopyN(out, tr, limit); err != nil && err != io.EOF {
+	written, err := io.Copy(out, io.LimitReader(tr, limit+1))
+	if err != nil {
 		out.Close()
 		return fmt.Errorf("write %s: %w", hdr.Name, err)
+	}
+	if written > limit {
+		out.Close()
+		return fmt.Errorf("archive entry %s exceeded size limit of %d bytes", hdr.Name, limit)
 	}
 	return out.Close()
 }

--- a/internal/binaryrelease/binaryrelease.go
+++ b/internal/binaryrelease/binaryrelease.go
@@ -9,6 +9,8 @@
 package binaryrelease
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -17,10 +19,20 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/nchapman/lleme/internal/fileutil"
 )
+
+// maxAPIBodyBytes caps the size of a GitHub API response we'll buffer. Real
+// release JSON is tens of KiB; 1 MiB is generous headroom with a hard ceiling.
+const maxAPIBodyBytes = 1 << 20
+
+// tarEntryMode masks permission bits from archive entries. We allow the
+// standard user/group/other triplets but strip setuid/setgid/sticky so a
+// compromised archive can't install a setuid binary.
+const tarEntryMode os.FileMode = 0755
 
 // Config bundles the policy knobs a caller passes into Download and
 // FetchLatestRelease. Keeping policy per-call (rather than in package state)
@@ -87,12 +99,14 @@ func ValidateURL(cfg Config, rawURL string) error {
 
 // FetchLatestRelease GETs the given GitHub releases/latest URL and decodes
 // the response into a Release. The apiURL is passed in (not constructed from
-// a repo string) so callers can override it in tests.
-func FetchLatestRelease(cfg Config, apiURL string) (*Release, error) {
+// a repo string) so callers can override it in tests. Response body is
+// bounded by maxAPIBodyBytes and redirects are revalidated against cfg via
+// the shared client, so the allow-list holds end-to-end.
+func FetchLatestRelease(ctx context.Context, cfg Config, apiURL string) (*Release, error) {
 	if err := ValidateURL(cfg, apiURL); err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -101,20 +115,20 @@ func FetchLatestRelease(cfg Config, apiURL string) (*Release, error) {
 		req.Header.Set("User-Agent", cfg.UserAgent)
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := newClient(cfg).Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
+	body := io.LimitReader(resp.Body, maxAPIBodyBytes)
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+		errBody, _ := io.ReadAll(body)
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(errBody))
 	}
 
 	var release Release
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+	if err := json.NewDecoder(body).Decode(&release); err != nil {
 		return nil, err
 	}
 	return &release, nil
@@ -156,16 +170,14 @@ func Download(ctx context.Context, cfg Config, downloadURL, destPath string, pro
 	return nil
 }
 
-func fetch(ctx context.Context, cfg Config, downloadURL string) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	if cfg.UserAgent != "" {
-		req.Header.Set("User-Agent", cfg.UserAgent)
-	}
-
-	client := &http.Client{
+// newClient builds the HTTP client used for every outbound request. The
+// CheckRedirect hook re-runs ValidateURL on each hop so the allow-list holds
+// across redirects; transport-level ResponseHeaderTimeout bounds connection
+// setup; the client Timeout bounds short metadata requests (callers pass
+// context for long downloads).
+func newClient(cfg Config) *http.Client {
+	return &http.Client{
+		Timeout:   30 * time.Second,
 		Transport: &http.Transport{ResponseHeaderTimeout: 30 * time.Second},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if err := ValidateURL(cfg, req.URL.String()); err != nil {
@@ -177,6 +189,21 @@ func fetch(ctx context.Context, cfg Config, downloadURL string) (*http.Response,
 			return nil
 		},
 	}
+}
+
+func fetch(ctx context.Context, cfg Config, downloadURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	if cfg.UserAgent != "" {
+		req.Header.Set("User-Agent", cfg.UserAgent)
+	}
+
+	// Downloads stream large bodies, so suppress the client-level deadline
+	// that newClient sets for metadata requests. CheckRedirect still applies.
+	client := newClient(cfg)
+	client.Timeout = 0
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -189,6 +216,10 @@ func fetch(ctx context.Context, cfg Config, downloadURL string) (*http.Response,
 	return resp, nil
 }
 
+// streamToFile copies src to tmpPath and returns the number of bytes it
+// wrote this call (independent of any StreamBody running-tally semantics).
+// The size cap is enforced via LimitReader(maxBytes+1); callers check the
+// returned count against their own max to detect a lying Content-Length.
 func streamToFile(src io.Reader, maxBytes, contentLength int64, tmpPath string, progress func(int64, int64)) (int64, error) {
 	out, err := os.Create(tmpPath)
 	if err != nil {
@@ -197,10 +228,131 @@ func streamToFile(src io.Reader, maxBytes, contentLength int64, tmpPath string, 
 	defer out.Close()
 
 	// Cap the body stream so a lying Content-Length can't fill the disk.
-	if maxBytes > 0 {
+	// The maxBytes+1 trick lets the caller detect the cap was hit (not a
+	// natural EOF). maxBytes < MaxInt64 is asserted by the caller — treat
+	// a nonsensical value as "no cap" rather than overflow to negative.
+	if maxBytes > 0 && maxBytes < (1<<62) {
 		src = io.LimitReader(src, maxBytes+1)
 	}
-	return fileutil.StreamBody(src, out, 0, contentLength, progress)
+	start := int64(0)
+	end, err := fileutil.StreamBody(src, out, start, contentLength, progress)
+	return end - start, err
+}
+
+// ExtractTarGz unpacks a .tar.gz archive into destDir, rejecting any entry
+// whose path would escape destDir (absolute paths, .. traversal, symlinks
+// pointing outside). Only regular files, directories, and same-tree
+// symlinks are extracted; hard links, devices, and setuid bits are dropped
+// so a malicious archive can't mutate files outside the extract tree.
+func ExtractTarGz(archivePath, destDir string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("open archive: %w", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	absDest, err := filepath.Abs(destDir)
+	if err != nil {
+		return fmt.Errorf("resolve destination: %w", err)
+	}
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read archive: %w", err)
+		}
+		if err := extractEntry(tr, hdr, absDest); err != nil {
+			return err
+		}
+	}
+}
+
+// safeJoin returns absDest/rel, guaranteed to live under absDest. Rejects
+// absolute entry names, .. traversal, and any path that lexically or via
+// symlink resolution escapes absDest.
+func safeJoin(absDest, name string) (string, error) {
+	clean := filepath.Clean(name)
+	if filepath.IsAbs(clean) {
+		return "", fmt.Errorf("archive entry %q has absolute path", name)
+	}
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("archive entry %q escapes destination", name)
+	}
+	joined := filepath.Join(absDest, clean)
+	if joined != absDest && !strings.HasPrefix(joined, absDest+string(filepath.Separator)) {
+		return "", fmt.Errorf("archive entry %q escapes destination", name)
+	}
+	return joined, nil
+}
+
+func extractEntry(tr *tar.Reader, hdr *tar.Header, absDest string) error {
+	target, err := safeJoin(absDest, hdr.Name)
+	if err != nil {
+		return err
+	}
+	mode := os.FileMode(hdr.Mode) & tarEntryMode
+
+	switch hdr.Typeflag {
+	case tar.TypeDir:
+		return os.MkdirAll(target, mode|0755)
+	case tar.TypeReg:
+		return writeTarFile(tr, hdr, target, mode)
+	case tar.TypeSymlink:
+		return writeTarSymlink(hdr, target, absDest)
+	default:
+		// Silently skip hard links, devices, fifos, etc. They aren't needed
+		// for the artifacts we install and extracting them would broaden the
+		// attack surface.
+		return nil
+	}
+}
+
+func writeTarFile(tr *tar.Reader, hdr *tar.Header, target string, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		return fmt.Errorf("mkdir parent of %s: %w", hdr.Name, err)
+	}
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode|0644)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", hdr.Name, err)
+	}
+	// Cap the per-entry copy so an inflated gzip bomb can't fill disk.
+	// hdr.Size<=0 means "unknown/empty"; clamp to a generous 8 GiB ceiling.
+	limit := hdr.Size
+	if limit <= 0 || limit > 1<<33 {
+		limit = 1 << 33
+	}
+	if _, err := io.CopyN(out, tr, limit); err != nil && err != io.EOF {
+		out.Close()
+		return fmt.Errorf("write %s: %w", hdr.Name, err)
+	}
+	return out.Close()
+}
+
+func writeTarSymlink(hdr *tar.Header, target, absDest string) error {
+	if filepath.IsAbs(hdr.Linkname) {
+		return fmt.Errorf("archive symlink %q has absolute target", hdr.Name)
+	}
+	resolved := filepath.Clean(filepath.Join(filepath.Dir(target), hdr.Linkname))
+	if resolved != absDest && !strings.HasPrefix(resolved, absDest+string(filepath.Separator)) {
+		return fmt.Errorf("archive symlink %q escapes destination", hdr.Name)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		return fmt.Errorf("mkdir parent of %s: %w", hdr.Name, err)
+	}
+	// Remove any pre-existing entry so Symlink doesn't fail with EEXIST
+	// on a re-extraction.
+	_ = os.Remove(target)
+	return os.Symlink(hdr.Linkname, target)
 }
 
 // SwapCurrentSymlink atomically points <dir>/<linkName> at target by staging

--- a/internal/binaryrelease/binaryrelease.go
+++ b/internal/binaryrelease/binaryrelease.go
@@ -1,0 +1,224 @@
+// Package binaryrelease contains platform-agnostic primitives for installing
+// third-party release artifacts (tarballs hosted on GitHub releases, fetched
+// over HTTPS, pinned by tag, activated via a "current" symlink).
+//
+// It owns the security-relevant parts: URL host/scheme allow-list, download
+// size caps, and the atomic symlink swap. Per-project concerns (which repo
+// to fetch, which asset matches the current platform, which tag formats to
+// accept, where the version file lives) stay in the caller.
+package binaryrelease
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/nchapman/lleme/internal/fileutil"
+)
+
+// Config bundles the policy knobs a caller passes into Download and
+// FetchLatestRelease. Keeping policy per-call (rather than in package state)
+// means callers can hold their own test hooks.
+//
+// Zero-value semantics are strict by design: a nil AllowedHosts or
+// AllowedSchemes map rejects every URL, which fails closed. MaxBytes is the
+// exception — 0 means unlimited. Callers should set it explicitly; the
+// package does not enforce a default ceiling, since some use cases
+// legitimately need it off.
+type Config struct {
+	AllowedHosts   map[string]bool // Hosts that may be contacted. nil blocks all.
+	AllowedSchemes map[string]bool // Schemes allowed (typically "https"). nil blocks all.
+	MaxBytes       int64           // Cap on downloaded bytes. 0 = unlimited.
+	UserAgent      string          // User-Agent header; omitted if empty.
+}
+
+// DefaultGitHubHosts are the hosts GitHub releases redirect through. github.com
+// issues 302 redirects to *.githubusercontent.com for asset downloads.
+func DefaultGitHubHosts() map[string]bool {
+	return map[string]bool{
+		"github.com":                           true,
+		"api.github.com":                       true,
+		"objects.githubusercontent.com":        true,
+		"release-assets.githubusercontent.com": true,
+		"releases.githubusercontent.com":       true,
+	}
+}
+
+// DefaultHTTPSOnly restricts downloads to https. Callers can extend this in
+// tests to permit http pointing at an httptest server.
+func DefaultHTTPSOnly() map[string]bool {
+	return map[string]bool{"https": true}
+}
+
+// Release is the minimal shape of a GitHub "latest release" response we use.
+type Release struct {
+	TagName string  `json:"tag_name"`
+	Name    string  `json:"name"`
+	Assets  []Asset `json:"assets"`
+}
+
+type Asset struct {
+	Name               string `json:"name"`
+	Size               int64  `json:"size"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// ValidateURL rejects URLs whose scheme or host is not on the allow-list.
+// Exported so callers can apply the same policy to redirect targets.
+func ValidateURL(cfg Config, rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+	if !cfg.AllowedSchemes[u.Scheme] {
+		return fmt.Errorf("URL scheme %q is not allowed", u.Scheme)
+	}
+	if !cfg.AllowedHosts[u.Hostname()] {
+		return fmt.Errorf("URL host %q is not on the allowlist", u.Hostname())
+	}
+	return nil
+}
+
+// FetchLatestRelease GETs the given GitHub releases/latest URL and decodes
+// the response into a Release. The apiURL is passed in (not constructed from
+// a repo string) so callers can override it in tests.
+func FetchLatestRelease(cfg Config, apiURL string) (*Release, error) {
+	if err := ValidateURL(cfg, apiURL); err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	if cfg.UserAgent != "" {
+		req.Header.Set("User-Agent", cfg.UserAgent)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var release Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, err
+	}
+	return &release, nil
+}
+
+// Download streams the given URL to destPath, atomically renaming from a
+// .partial once complete. Enforces the configured host/scheme/size limits
+// and validates redirects against the same policy.
+func Download(ctx context.Context, cfg Config, downloadURL, destPath string, progress func(int64, int64)) error {
+	if err := ValidateURL(cfg, downloadURL); err != nil {
+		return err
+	}
+
+	resp, err := fetch(ctx, cfg, downloadURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if cfg.MaxBytes > 0 && resp.ContentLength > cfg.MaxBytes {
+		return fmt.Errorf("download %s: content-length %d exceeds max %d", downloadURL, resp.ContentLength, cfg.MaxBytes)
+	}
+
+	tmpPath := destPath + ".partial"
+	written, err := streamToFile(resp.Body, cfg.MaxBytes, resp.ContentLength, tmpPath, progress)
+	if err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("write to %s: %w", tmpPath, err)
+	}
+	if cfg.MaxBytes > 0 && written > cfg.MaxBytes {
+		os.Remove(tmpPath)
+		return fmt.Errorf("download %s exceeded max size of %d bytes", downloadURL, cfg.MaxBytes)
+	}
+
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename %s to %s: %w", tmpPath, destPath, err)
+	}
+	return nil
+}
+
+func fetch(ctx context.Context, cfg Config, downloadURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	if cfg.UserAgent != "" {
+		req.Header.Set("User-Agent", cfg.UserAgent)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{ResponseHeaderTimeout: 30 * time.Second},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if err := ValidateURL(cfg, req.URL.String()); err != nil {
+				return fmt.Errorf("redirect blocked: %w", err)
+			}
+			if len(via) >= 10 {
+				return fmt.Errorf("too many redirects")
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", downloadURL, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("download %s: HTTP %d", downloadURL, resp.StatusCode)
+	}
+	return resp, nil
+}
+
+func streamToFile(src io.Reader, maxBytes, contentLength int64, tmpPath string, progress func(int64, int64)) (int64, error) {
+	out, err := os.Create(tmpPath)
+	if err != nil {
+		return 0, fmt.Errorf("create %s: %w", tmpPath, err)
+	}
+	defer out.Close()
+
+	// Cap the body stream so a lying Content-Length can't fill the disk.
+	if maxBytes > 0 {
+		src = io.LimitReader(src, maxBytes+1)
+	}
+	return fileutil.StreamBody(src, out, 0, contentLength, progress)
+}
+
+// SwapCurrentSymlink atomically points <dir>/<linkName> at target by staging
+// a tmp symlink and renaming it into place. Avoids the ENOENT window a
+// remove+symlink pair would expose to concurrent exec.Command calls.
+func SwapCurrentSymlink(dir, linkName, target string) error {
+	currentLink := filepath.Join(dir, linkName)
+	tmpLink := filepath.Join(dir, "."+linkName+".tmp")
+
+	// A stale tmp from a prior failed run would make Symlink fail with EEXIST.
+	_ = os.Remove(tmpLink)
+
+	if err := os.Symlink(target, tmpLink); err != nil {
+		return fmt.Errorf("stage %s symlink: %w", linkName, err)
+	}
+	if err := os.Rename(tmpLink, currentLink); err != nil {
+		_ = os.Remove(tmpLink)
+		return fmt.Errorf("activate %s symlink: %w", linkName, err)
+	}
+	return nil
+}

--- a/internal/binaryrelease/binaryrelease_test.go
+++ b/internal/binaryrelease/binaryrelease_test.go
@@ -1,6 +1,9 @@
 package binaryrelease
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"net/http"
@@ -68,7 +71,7 @@ func TestFetchLatestRelease(t *testing.T) {
 	defer srv.Close()
 
 	cfg := testConfig(t, srv)
-	rel, err := FetchLatestRelease(cfg, srv.URL+"/releases/latest")
+	rel, err := FetchLatestRelease(context.Background(), cfg, srv.URL+"/releases/latest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +85,7 @@ func TestFetchLatestReleaseRejectsDisallowedHost(t *testing.T) {
 		AllowedHosts:   map[string]bool{"api.github.com": true},
 		AllowedSchemes: DefaultHTTPSOnly(),
 	}
-	_, err := FetchLatestRelease(cfg, "https://evil.example.com/repos/x/y/releases/latest")
+	_, err := FetchLatestRelease(context.Background(), cfg, "https://evil.example.com/repos/x/y/releases/latest")
 	if err == nil || !strings.Contains(err.Error(), "allowlist") {
 		t.Errorf("err = %v, want allowlist rejection", err)
 	}
@@ -157,6 +160,118 @@ func TestDownloadRejectsDisallowedHost(t *testing.T) {
 	err := Download(context.Background(), cfg, "https://evil.example.com/a", "/tmp/x", nil)
 	if err == nil || !strings.Contains(err.Error(), "allowlist") {
 		t.Errorf("err = %v, want allowlist rejection", err)
+	}
+}
+
+// writeTarGz builds a .tar.gz in tmpDir from the given entries. Each entry
+// is (typeflag, name, linkname, body). Returns the archive path.
+type tarEntry struct {
+	typ      byte
+	name     string
+	linkname string
+	body     string
+}
+
+func writeTarGz(t *testing.T, entries []tarEntry) string {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Name:     e.name,
+			Typeflag: e.typ,
+			Mode:     0644,
+			Size:     int64(len(e.body)),
+			Linkname: e.linkname,
+		}
+		if e.typ == tar.TypeDir {
+			hdr.Mode = 0755
+			hdr.Size = 0
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if e.typ == tar.TypeReg && e.body != "" {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(t.TempDir(), "arc.tar.gz")
+	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestExtractTarGzHappyPath(t *testing.T) {
+	arc := writeTarGz(t, []tarEntry{
+		{typ: tar.TypeDir, name: "pkg/"},
+		{typ: tar.TypeReg, name: "pkg/bin", body: "hello"},
+		{typ: tar.TypeSymlink, name: "pkg/link", linkname: "bin"},
+	})
+	dest := t.TempDir()
+	if err := ExtractTarGz(arc, dest); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "pkg", "bin"))
+	if err != nil || string(got) != "hello" {
+		t.Errorf("bin: got %q err %v", got, err)
+	}
+	target, err := os.Readlink(filepath.Join(dest, "pkg", "link"))
+	if err != nil || target != "bin" {
+		t.Errorf("link: got %q err %v", target, err)
+	}
+}
+
+func TestExtractTarGzRejectsPathTraversal(t *testing.T) {
+	cases := []struct {
+		name  string
+		entry tarEntry
+	}{
+		{"absolute path", tarEntry{typ: tar.TypeReg, name: "/etc/evil", body: "x"}},
+		{"dotdot", tarEntry{typ: tar.TypeReg, name: "../escape", body: "x"}},
+		{"dotdot nested", tarEntry{typ: tar.TypeReg, name: "good/../../escape", body: "x"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			arc := writeTarGz(t, []tarEntry{tc.entry})
+			dest := t.TempDir()
+			err := ExtractTarGz(arc, dest)
+			if err == nil || !strings.Contains(err.Error(), "escape") && !strings.Contains(err.Error(), "absolute") {
+				t.Errorf("err = %v, want traversal rejection", err)
+			}
+		})
+	}
+}
+
+func TestExtractTarGzRejectsEscapingSymlink(t *testing.T) {
+	arc := writeTarGz(t, []tarEntry{
+		{typ: tar.TypeSymlink, name: "escape", linkname: "../../../outside"},
+	})
+	dest := t.TempDir()
+	err := ExtractTarGz(arc, filepath.Join(dest, "inner"))
+	if err == nil || !strings.Contains(err.Error(), "escape") {
+		t.Errorf("err = %v, want symlink escape rejection", err)
+	}
+}
+
+func TestExtractTarGzRejectsAbsoluteSymlink(t *testing.T) {
+	arc := writeTarGz(t, []tarEntry{
+		{typ: tar.TypeSymlink, name: "link", linkname: "/etc/passwd"},
+	})
+	dest := t.TempDir()
+	err := ExtractTarGz(arc, dest)
+	if err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Errorf("err = %v, want absolute-symlink rejection", err)
 	}
 }
 

--- a/internal/binaryrelease/binaryrelease_test.go
+++ b/internal/binaryrelease/binaryrelease_test.go
@@ -264,6 +264,25 @@ func TestExtractTarGzRejectsEscapingSymlink(t *testing.T) {
 	}
 }
 
+// Baseline: an archive whose declared sizes match their payloads must
+// extract cleanly under the new io.Copy(LimitReader(limit+1)) code path
+// — guards against a regression where the `written > limit` check trips
+// on exact matches.
+func TestExtractTarGzMatchedSize(t *testing.T) {
+	payload := strings.Repeat("A", 1024)
+	arc := writeTarGz(t, []tarEntry{
+		{typ: tar.TypeReg, name: "exact", body: payload},
+	})
+	dest := t.TempDir()
+	if err := ExtractTarGz(arc, dest); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "exact"))
+	if err != nil || string(got) != payload {
+		t.Errorf("content mismatch: %d bytes err=%v", len(got), err)
+	}
+}
+
 func TestExtractTarGzRejectsAbsoluteSymlink(t *testing.T) {
 	arc := writeTarGz(t, []tarEntry{
 		{typ: tar.TypeSymlink, name: "link", linkname: "/etc/passwd"},

--- a/internal/binaryrelease/binaryrelease_test.go
+++ b/internal/binaryrelease/binaryrelease_test.go
@@ -1,0 +1,197 @@
+package binaryrelease
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testConfig(t *testing.T, srv *httptest.Server) Config {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse srv url: %v", err)
+	}
+	return Config{
+		AllowedHosts:   map[string]bool{u.Hostname(): true},
+		AllowedSchemes: map[string]bool{"http": true},
+		MaxBytes:       1 << 20,
+		UserAgent:      "lleme-test",
+	}
+}
+
+func TestValidateURL(t *testing.T) {
+	cfg := Config{
+		AllowedHosts:   map[string]bool{"github.com": true},
+		AllowedSchemes: map[string]bool{"https": true},
+	}
+	tests := []struct {
+		name    string
+		url     string
+		wantErr string
+	}{
+		{"good", "https://github.com/foo/bar/releases/download/v1/a.tar.gz", ""},
+		{"bad scheme", "http://github.com/x", "scheme \"http\""},
+		{"bad host", "https://evil.example.com/x", "host \"evil.example.com\""},
+		{"bad url", "://not a url", "invalid URL"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateURL(cfg, tt.url)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("got %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("err = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFetchLatestRelease(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ua := r.Header.Get("User-Agent"); ua != "lleme-test" {
+			t.Errorf("User-Agent = %q, want lleme-test", ua)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"tag_name":"b517","name":"Release","assets":[{"name":"a.tar.gz","size":1024,"browser_download_url":"https://example.invalid/a.tar.gz"}]}`)
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(t, srv)
+	rel, err := FetchLatestRelease(cfg, srv.URL+"/releases/latest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rel.TagName != "b517" || len(rel.Assets) != 1 || rel.Assets[0].Name != "a.tar.gz" {
+		t.Errorf("unexpected release: %+v", rel)
+	}
+}
+
+func TestFetchLatestReleaseRejectsDisallowedHost(t *testing.T) {
+	cfg := Config{
+		AllowedHosts:   map[string]bool{"api.github.com": true},
+		AllowedSchemes: DefaultHTTPSOnly(),
+	}
+	_, err := FetchLatestRelease(cfg, "https://evil.example.com/repos/x/y/releases/latest")
+	if err == nil || !strings.Contains(err.Error(), "allowlist") {
+		t.Errorf("err = %v, want allowlist rejection", err)
+	}
+}
+
+func TestDownload(t *testing.T) {
+	payload := strings.Repeat("x", 300)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+		fmt.Fprint(w, payload)
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(t, srv)
+	dest := filepath.Join(t.TempDir(), "out.bin")
+	if err := Download(context.Background(), cfg, srv.URL+"/artifact", dest, nil); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(data) != payload {
+		t.Errorf("got %d bytes, want %d", len(data), len(payload))
+	}
+}
+
+func TestDownloadRejectsOversizedContentLength(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "99999")
+		fmt.Fprint(w, "small")
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(t, srv)
+	cfg.MaxBytes = 100
+	err := Download(context.Background(), cfg, srv.URL+"/artifact", filepath.Join(t.TempDir(), "x"), nil)
+	if err == nil || !strings.Contains(err.Error(), "exceeds max") {
+		t.Errorf("err = %v, want content-length exceeded", err)
+	}
+}
+
+func TestDownloadRejectsOversizedBody(t *testing.T) {
+	// Chunked response: no Content-Length header, so the first guard can't
+	// catch it and the streamed-bytes guard must.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, _ := w.(http.Flusher)
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		_, _ = w.Write([]byte(strings.Repeat("y", 500)))
+	}))
+	defer srv.Close()
+
+	cfg := testConfig(t, srv)
+	cfg.MaxBytes = 50
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "x")
+	err := Download(context.Background(), cfg, srv.URL+"/artifact", dest, nil)
+	if err == nil || !strings.Contains(err.Error(), "max size") {
+		t.Errorf("err = %v, want body exceeded", err)
+	}
+	if _, err := os.Stat(dest + ".partial"); !os.IsNotExist(err) {
+		t.Errorf(".partial file should be cleaned up after size rejection (err: %v)", err)
+	}
+}
+
+func TestDownloadRejectsDisallowedHost(t *testing.T) {
+	cfg := Config{
+		AllowedHosts:   map[string]bool{"github.com": true},
+		AllowedSchemes: map[string]bool{"https": true},
+	}
+	err := Download(context.Background(), cfg, "https://evil.example.com/a", "/tmp/x", nil)
+	if err == nil || !strings.Contains(err.Error(), "allowlist") {
+		t.Errorf("err = %v, want allowlist rejection", err)
+	}
+}
+
+func TestSwapCurrentSymlink(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "v1"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "v2"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SwapCurrentSymlink(dir, "current", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	target, err := os.Readlink(filepath.Join(dir, "current"))
+	if err != nil || target != "v1" {
+		t.Errorf("first swap: target=%q err=%v", target, err)
+	}
+
+	// Second swap replaces the link atomically.
+	if err := SwapCurrentSymlink(dir, "current", "v2"); err != nil {
+		t.Fatal(err)
+	}
+	target, err = os.Readlink(filepath.Join(dir, "current"))
+	if err != nil || target != "v2" {
+		t.Errorf("second swap: target=%q err=%v", target, err)
+	}
+
+	// A leftover .current.tmp should not block a swap.
+	tmp := filepath.Join(dir, ".current.tmp")
+	if err := os.Symlink("stale", tmp); err != nil {
+		t.Fatal(err)
+	}
+	if err := SwapCurrentSymlink(dir, "current", "v1"); err != nil {
+		t.Errorf("swap with stale tmp: %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	HuggingFace HuggingFace `yaml:"huggingface"`
 	Server      Server      `yaml:"server"`
 	LlamaCpp    LlamaCpp    `yaml:"llamacpp"`
+	SwiftLM     SwiftLM     `yaml:"swiftlm"`
 }
 
 type HuggingFace struct {
@@ -58,6 +59,12 @@ type LlamaCpp struct {
 	ServerPath string         `yaml:"server_path,omitempty"`
 	AutoUpdate *bool          `yaml:"auto_update,omitempty"`
 	Options    map[string]any `yaml:"options,omitempty"`
+}
+
+// SwiftLM holds settings for the MLX / SwiftLM runtime. Scoped separately
+// from LlamaCpp so flags from one backend don't bleed into the other.
+type SwiftLM struct {
+	Options map[string]any `yaml:"options,omitempty"`
 }
 
 // AutoUpdateEnabled reports whether background llama.cpp updates are enabled.
@@ -222,6 +229,29 @@ llamacpp:
 
     # --- Reasoning models ---
     # reasoning-format: auto   # Thinking token handling (auto, none, deepseek)
+
+# SwiftLM (MLX) server settings — only applies to MLX-format models on
+# Apple Silicon. Unknown keys are silently dropped, so llamacpp options
+# above won't break MLX backends.
+swiftlm:
+  # options:
+    # --- Core ---
+    # ctx-size: 8192           # Context window (KV cache)
+    # max-tokens: 2048         # Default max tokens per request
+    # parallel: 1              # Parallel request slots
+    # gpu-layers: auto         # "auto" or integer
+
+    # --- Sampling defaults (overridable per request) ---
+    # temp: 0.6                # Temperature (0 = greedy)
+    # top-p: 1.0               # Top-p / nucleus sampling
+    # top-k: 50                # Top-k (0 = disabled)
+    # min-p: 0.0               # Min-p sampling
+    # repeat-penalty: 1.0      # Repetition penalty
+
+    # --- Mode toggles ---
+    # thinking: false          # Qwen3.5-style reasoning mode
+    # vision: false            # Enable VLM (image inputs)
+    # audio: false             # Enable ALM (audio inputs)
 `
 
 func Load() (*Config, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,12 +64,24 @@ type LlamaCpp struct {
 // SwiftLM holds settings for the MLX / SwiftLM runtime. Scoped separately
 // from LlamaCpp so flags from one backend don't bleed into the other.
 type SwiftLM struct {
-	Options map[string]any `yaml:"options,omitempty"`
+	AutoUpdate *bool          `yaml:"auto_update,omitempty"`
+	Options    map[string]any `yaml:"options,omitempty"`
 }
 
 // AutoUpdateEnabled reports whether background llama.cpp updates are enabled.
 // Defaults to true when unset so fresh installs stay current without manual action.
 func (c *LlamaCpp) AutoUpdateEnabled() bool {
+	if c.AutoUpdate == nil {
+		return true
+	}
+	return *c.AutoUpdate
+}
+
+// AutoUpdateEnabled reports whether background SwiftLM updates are enabled.
+// Defaults to true for parity with LlamaCpp. No-ops on non-darwin-arm64
+// platforms regardless of this setting — gated by swiftlm.IsSupported() at
+// the call site.
+func (c *SwiftLM) AutoUpdateEnabled() bool {
 	if c.AutoUpdate == nil {
 		return true
 	}
@@ -234,6 +246,11 @@ llamacpp:
 # Apple Silicon. Unknown keys are silently dropped, so llamacpp options
 # above won't break MLX backends.
 swiftlm:
+  # Auto-update SwiftLM in the background on server start (default: true).
+  # Has no effect on non-Apple-Silicon hosts since SwiftLM isn't supported
+  # there.
+  # auto_update: true
+
   # options:
     # --- Core ---
     # ctx-size: 8192           # Context window (KV cache)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,7 +56,6 @@ type HuggingFace struct {
 }
 
 type LlamaCpp struct {
-	ServerPath string         `yaml:"server_path,omitempty"`
 	AutoUpdate *bool          `yaml:"auto_update,omitempty"`
 	Options    map[string]any `yaml:"options,omitempty"`
 }
@@ -202,9 +201,6 @@ server:
 # All options here are passed directly to llama-server.
 # See 'llama-server --help' for the full list.
 llamacpp:
-  # Path to llama-server binary (empty = auto-detect)
-  # server_path: ""
-
   # Auto-update llama.cpp in the background on server start (default: true)
   # llama.cpp ships frequently; newer builds fix issues with newly released
   # models. Disable if you want to pin a known-good version.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -320,6 +320,17 @@ func (c *LlamaCpp) GetOption(key string) (any, bool) {
 	return val, ok
 }
 
+// GetOption returns a SwiftLM option value from the config.
+// Mirrors LlamaCpp.GetOption so the options.Resolver can dispatch by
+// backend kind without peeking at field names.
+func (c *SwiftLM) GetOption(key string) (any, bool) {
+	if c.Options == nil {
+		return nil, false
+	}
+	val, ok := c.Options[key]
+	return val, ok
+}
+
 func EnsureDirectories() error {
 	dirs := []string{
 		ConfigPath(),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,9 +22,6 @@ func TestDefaultConfig(t *testing.T) {
 	}
 
 	// LlamaCpp defaults - should be empty (let llama-server use its defaults)
-	if cfg.LlamaCpp.ServerPath != "" {
-		t.Errorf("Expected empty LlamaCpp.ServerPath, got %s", cfg.LlamaCpp.ServerPath)
-	}
 	if cfg.LlamaCpp.Options != nil {
 		t.Errorf("Expected nil LlamaCpp.Options, got %v", cfg.LlamaCpp.Options)
 	}
@@ -73,7 +70,6 @@ func TestLoad(t *testing.T) {
   token: test-token
   default_quant: Q5_K
 llamacpp:
-  server_path: /custom/path
   options:
     ctx-size: 2048
     gpu-layers: 35
@@ -103,12 +99,7 @@ server:
 			t.Errorf("Expected HuggingFace.DefaultQuant Q5_K, got %s", cfg.HuggingFace.DefaultQuant)
 		}
 
-		// LlamaCpp
-		if cfg.LlamaCpp.ServerPath != "/custom/path" {
-			t.Errorf("Expected LlamaCpp.ServerPath /custom/path, got %s", cfg.LlamaCpp.ServerPath)
-		}
-
-		// Options
+		// LlamaCpp Options
 		if v, ok := cfg.LlamaCpp.GetOption("ctx-size"); !ok || v != 2048 {
 			t.Errorf("Expected ctx-size 2048, got %v (ok=%v)", v, ok)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -279,14 +279,14 @@ func TestGetOption(t *testing.T) {
 func TestGetServerOptions(t *testing.T) {
 	t.Run("nil persona returns nil", func(t *testing.T) {
 		var p *Persona
-		if got := p.GetServerOptions(); got != nil {
+		if got := p.GetServerOptions(""); got != nil {
 			t.Errorf("Expected nil, got %v", got)
 		}
 	})
 
 	t.Run("empty options returns nil", func(t *testing.T) {
 		p := &Persona{}
-		if got := p.GetServerOptions(); got != nil {
+		if got := p.GetServerOptions(""); got != nil {
 			t.Errorf("Expected nil, got %v", got)
 		}
 	})
@@ -303,7 +303,7 @@ func TestGetServerOptions(t *testing.T) {
 				"dry-multiplier":       0.8,
 			},
 		}
-		got := p.GetServerOptions()
+		got := p.GetServerOptions("")
 		if got == nil {
 			t.Fatal("Expected non-nil options")
 		}
@@ -331,10 +331,37 @@ func TestGetServerOptions(t *testing.T) {
 		}
 	})
 
+	t.Run("backend-specific options layer on shared", func(t *testing.T) {
+		p := &Persona{
+			Options:  map[string]any{"temp": 0.7, "top-k": 40},
+			LlamaCpp: PersonaBackendSection{Options: map[string]any{"mirostat": 2, "temp": 0.5}},
+			SwiftLM:  PersonaBackendSection{Options: map[string]any{"turbo-kv": true}},
+		}
+
+		gguf := p.GetServerOptions("gguf")
+		if gguf["temp"] != 0.5 {
+			t.Errorf("gguf temp = %v, want 0.5 (llamacpp overrides shared)", gguf["temp"])
+		}
+		if gguf["mirostat"] != 2 {
+			t.Errorf("gguf mirostat = %v, want 2", gguf["mirostat"])
+		}
+		if _, ok := gguf["turbo-kv"]; ok {
+			t.Error("gguf leaked swiftlm-only option")
+		}
+
+		mlx := p.GetServerOptions("mlx")
+		if mlx["turbo-kv"] != true {
+			t.Error("mlx missing turbo-kv")
+		}
+		if _, ok := mlx["mirostat"]; ok {
+			t.Error("mlx leaked llamacpp-only option")
+		}
+	})
+
 	t.Run("returns a copy, not the original map", func(t *testing.T) {
 		opts := map[string]any{"temp": 0.8}
 		p := &Persona{Options: opts}
-		got := p.GetServerOptions()
+		got := p.GetServerOptions("")
 		if got == nil {
 			t.Fatal("Expected non-nil options")
 		}

--- a/internal/config/persona.go
+++ b/internal/config/persona.go
@@ -55,6 +55,11 @@ func (p *Persona) GetServerOptions(kind string) map[string]any {
 }
 
 // backendOptions returns the Options map for the given backend kind, or nil.
+// Kind strings mirror the hf package's BackendGGUF / BackendMLX constants;
+// kept as string literals here to avoid importing hf and creating a
+// config → hf dependency (hf already depends on config). If these strings
+// ever drift, the hf package's parseBackendKind will reject the value and
+// the selectRuntime switch will surface the mismatch.
 func (p *Persona) backendOptions(kind string) map[string]any {
 	switch kind {
 	case "gguf":

--- a/internal/config/persona.go
+++ b/internal/config/persona.go
@@ -9,24 +9,60 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Persona represents a saved model configuration with optional system prompt and options.
-type Persona struct {
-	Model   string         `yaml:"model,omitempty"`
-	System  string         `yaml:"system,omitempty"`
+// PersonaBackendSection holds runtime-specific option overrides. When set,
+// these layer on top of Persona.Options for the matching backend only.
+type PersonaBackendSection struct {
 	Options map[string]any `yaml:"options,omitempty"`
 }
 
-// GetServerOptions returns all persona options to pass to the model loading API.
-// Returns a shallow copy to prevent callers from mutating persona state.
-func (p *Persona) GetServerOptions() map[string]any {
-	if p == nil || len(p.Options) == 0 {
+// Persona represents a saved model configuration with optional system prompt and options.
+//
+// Options layering (per backend) is:
+//
+//	shared Options → backend-specific Options (later wins)
+//
+// so a persona that sets temp globally and repeat-penalty only under
+// llamacpp emits both flags for a GGUF model and only the shared temp for an
+// MLX model.
+type Persona struct {
+	Model    string                `yaml:"model,omitempty"`
+	System   string                `yaml:"system,omitempty"`
+	Options  map[string]any        `yaml:"options,omitempty"`
+	LlamaCpp PersonaBackendSection `yaml:"llamacpp,omitempty"`
+	SwiftLM  PersonaBackendSection `yaml:"swiftlm,omitempty"`
+}
+
+// GetServerOptions returns all persona options to pass to the model loading
+// API, layered for the given backend kind (hf.BackendGGUF / hf.BackendMLX).
+// An empty kind applies only the shared Options map. Returns a shallow copy
+// to prevent callers from mutating persona state.
+func (p *Persona) GetServerOptions(kind string) map[string]any {
+	if p == nil {
 		return nil
 	}
-	out := make(map[string]any, len(p.Options))
+	specific := p.backendOptions(kind)
+	if len(p.Options) == 0 && len(specific) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(p.Options)+len(specific))
 	for k, v := range p.Options {
 		out[k] = v
 	}
+	for k, v := range specific {
+		out[k] = v
+	}
 	return out
+}
+
+// backendOptions returns the Options map for the given backend kind, or nil.
+func (p *Persona) backendOptions(kind string) map[string]any {
+	switch kind {
+	case "gguf":
+		return p.LlamaCpp.Options
+	case "mlx":
+		return p.SwiftLM.Options
+	}
+	return nil
 }
 
 const personasDir = "personas"
@@ -126,12 +162,20 @@ func writePersonaSystemSection(b *strings.Builder, persona *Persona) {
 }
 
 func writePersonaOptionsSection(b *strings.Builder, persona *Persona) error {
-	b.WriteString("# llama.cpp options (same as config llamacpp.options)\n")
+	b.WriteString("# Shared options — applied to whatever backend the model uses.\n")
 	b.WriteString("# options:\n")
 	b.WriteString("#   temp: 0.8\n")
 	b.WriteString("#   top-p: 0.9\n")
 	b.WriteString("#   top-k: 40\n")
 	b.WriteString("#   repeat-penalty: 1.0\n")
+	b.WriteString("#\n")
+	b.WriteString("# Backend-specific overrides layer on top of shared options:\n")
+	b.WriteString("# llamacpp:\n")
+	b.WriteString("#   options:\n")
+	b.WriteString("#     mirostat: 2\n")
+	b.WriteString("# swiftlm:\n")
+	b.WriteString("#   options:\n")
+	b.WriteString("#     turbo-kv: true\n")
 
 	if len(persona.Options) == 0 {
 		return nil

--- a/internal/hf/client.go
+++ b/internal/hf/client.go
@@ -242,12 +242,20 @@ func (c *Client) ListFilesInPath(user, repo, branch, path string) ([]FileTree, e
 	return files, nil
 }
 
-func (c *Client) SearchModels(query string, limit int) ([]SearchResult, error) {
-	// Use models-json endpoint with apps=llama.cpp filter for llama.cpp compatible models
-	searchURL := fmt.Sprintf("%s/models-json?apps=llama.cpp&sort=trending", baseURL)
-	if query != "" {
-		searchURL += "&search=" + url.QueryEscape(query)
+// SearchModels queries HuggingFace's models-json endpoint. apps filters to
+// compatible runtimes (e.g. "llama.cpp", "mlx-lm"); callers typically join
+// the names of all registered backends. An empty apps is allowed but
+// unfiltered results are noisy, so callers should pass something.
+func (c *Client) SearchModels(query string, limit int, apps []string) ([]SearchResult, error) {
+	params := url.Values{}
+	params.Set("sort", "trending")
+	if len(apps) > 0 {
+		params.Set("apps", strings.Join(apps, ","))
 	}
+	if query != "" {
+		params.Set("search", query)
+	}
+	searchURL := fmt.Sprintf("%s/models-json?%s", baseURL, params.Encode())
 	req, err := http.NewRequest("GET", searchURL, nil)
 	if err != nil {
 		return nil, err

--- a/internal/hf/client.go
+++ b/internal/hf/client.go
@@ -121,6 +121,18 @@ type Manifest struct {
 	SplitFiles []*ManifestFile `json:"splitFiles,omitempty"` // Additional split files (local augmentation)
 }
 
+// hfAllowedHosts is the set of hosts the HuggingFace download client is
+// permitted to contact, including the LFS CDN that huggingface.co redirects
+// to for large files. Any other host on a redirect chain fails closed.
+var hfAllowedHosts = map[string]bool{
+	"huggingface.co":          true,
+	"hf.co":                   true,
+	"cdn-lfs.huggingface.co":  true,
+	"cdn-lfs.hf.co":           true,
+	"cas-bridge.xethub.hf.co": true,
+	"cas-server.xethub.hf.co": true,
+}
+
 func NewClient(cfg *config.Config) *Client {
 	return &Client{
 		httpClient: &http.Client{
@@ -129,6 +141,21 @@ func NewClient(cfg *config.Config) *Client {
 		downloadClient: &http.Client{
 			Transport: &http.Transport{
 				ResponseHeaderTimeout: 30 * time.Second,
+			},
+			// Validate every redirect hop. Without this, a compromised HF
+			// response could 302 the download to an arbitrary host and the
+			// Authorization header would follow.
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if !hfAllowedHosts[req.URL.Hostname()] {
+					return fmt.Errorf("redirect blocked: %s is not on the HuggingFace download allowlist", req.URL.Hostname())
+				}
+				if req.URL.Scheme != "https" {
+					return fmt.Errorf("redirect blocked: scheme %q is not https", req.URL.Scheme)
+				}
+				if len(via) >= 10 {
+					return fmt.Errorf("too many redirects")
+				}
+				return nil
 			},
 		},
 		token: getToken(cfg),

--- a/internal/hf/download.go
+++ b/internal/hf/download.go
@@ -315,6 +315,27 @@ const (
 	BackendMLX  = "mlx"
 )
 
+// BackendKindForModelName parses a "user/repo:quant" reference and resolves
+// its backend kind via metadata.yaml. Falls back to BackendGGUF for any
+// parse or read error — callers treat the result as a hint for layering
+// backend-specific options, not an authoritative runtime selection.
+func BackendKindForModelName(fullName string) string {
+	colon := strings.LastIndex(fullName, ":")
+	if colon < 0 {
+		return BackendGGUF
+	}
+	repoPart, quant := fullName[:colon], fullName[colon+1:]
+	slash := strings.Index(repoPart, "/")
+	if slash < 0 {
+		return BackendGGUF
+	}
+	kind, err := GetBackendKind(repoPart[:slash], repoPart[slash+1:], quant)
+	if err != nil {
+		return BackendGGUF
+	}
+	return kind
+}
+
 // GetBackendKind returns the recorded backend kind for a quant. A missing
 // metadata file or an empty `backend:` field resolves to "gguf" (the only
 // format lleme supported before MLX). I/O and parse errors are propagated

--- a/internal/hf/download.go
+++ b/internal/hf/download.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/nchapman/lleme/internal/config"
 	"github.com/nchapman/lleme/internal/fileutil"
+	"github.com/nchapman/lleme/internal/logs"
 	"github.com/nchapman/lleme/internal/version"
 	"gopkg.in/yaml.v3"
 )
@@ -387,6 +388,11 @@ func BackendKindForModelName(fullName string) string {
 	}
 	kind, err := GetBackendKind(repoPart[:slash], repoPart[slash+1:], quant)
 	if err != nil {
+		// Genuinely corrupt / unreadable metadata lands here; the "missing
+		// file" case returns (BackendGGUF, nil) and stays silent. Warn so a
+		// user seeing the wrong runtime dispatched to an MLX model has a
+		// log entry to correlate with.
+		logs.Warn("BackendKindForModelName falling back to gguf", "model", fullName, "error", err)
 		return BackendGGUF
 	}
 	return kind

--- a/internal/hf/download.go
+++ b/internal/hf/download.go
@@ -339,7 +339,10 @@ func BackendKindForModelName(fullName string) string {
 // GetBackendKind returns the recorded backend kind for a quant. A missing
 // metadata file or an empty `backend:` field resolves to "gguf" (the only
 // format lleme supported before MLX). I/O and parse errors are propagated
-// so callers can surface them instead of silently falling back.
+// so callers can surface them instead of silently falling back. Any
+// unrecognized backend string in the file is an error — metadata.yaml is
+// local, but corrupt / tampered content shouldn't silently dispatch to a
+// default runtime.
 func GetBackendKind(user, repo, quant string) (string, error) {
 	meta, err := LoadMetadata(user, repo)
 	if err != nil {
@@ -349,7 +352,18 @@ func GetBackendKind(user, repo, quant string) (string, error) {
 	if !ok || q.Backend == "" {
 		return BackendGGUF, nil
 	}
-	return q.Backend, nil
+	return parseBackendKind(q.Backend)
+}
+
+// parseBackendKind accepts only the known kinds. Keeps the on-disk
+// vocabulary narrow so downstream switches don't have to re-validate.
+func parseBackendKind(s string) (string, error) {
+	switch s {
+	case BackendGGUF, BackendMLX:
+		return s, nil
+	default:
+		return "", fmt.Errorf("unrecognized backend kind %q", s)
+	}
 }
 
 // TouchLastUsed updates the last used timestamp for a model.

--- a/internal/hf/download.go
+++ b/internal/hf/download.go
@@ -41,50 +41,27 @@ func NewDownloaderWithProgress(client *Client, progress ProgressCallback) *Downl
 	}
 }
 
-func (d *Downloader) DownloadModel(user, repo, branch, filename string, destPath string) (*DownloadProgress, error) {
-	url := fmt.Sprintf("%s/%s/%s/resolve/%s/%s", baseURL, user, repo, branch, filename)
-
+// DownloadModel streams a file from HuggingFace to destPath. expectedSize
+// (bytes) is the manifest-declared size; when non-zero it caps the total
+// bytes written at 2× the declared size as a defense against a misbehaving
+// or malicious backend streaming unbounded content. Zero disables the cap.
+func (d *Downloader) DownloadModel(user, repo, branch, filename, destPath string, expectedSize int64) (*DownloadProgress, error) {
 	partialPath := destPath + ".partial"
-	fileSize := int64(0)
+	existing := existingPartialSize(partialPath)
 
-	if info, err := os.Stat(partialPath); err == nil {
-		fileSize = info.Size()
-	}
-
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("User-Agent", version.UserAgent())
-	if d.client.token != "" {
-		req.Header.Set("Authorization", "Bearer "+d.client.token)
-	}
-
-	if fileSize > 0 {
-		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", fileSize))
-	}
-
-	resp, err := d.client.downloadClient.Do(req)
+	resp, err := d.dispatchDownload(user, repo, branch, filename, existing)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
-		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	totalSize := existing + resp.ContentLength
+	sizeCap, err := enforceSizeCap(filename, expectedSize, totalSize)
+	if err != nil {
+		return nil, err
 	}
 
-	totalSize := fileSize + resp.ContentLength
-
-	flags := os.O_CREATE | os.O_WRONLY
-	if resp.StatusCode == http.StatusOK {
-		flags |= os.O_TRUNC
-	} else {
-		flags |= os.O_APPEND
-	}
-
-	file, err := os.OpenFile(partialPath, flags, 0644)
+	file, err := openDownloadFile(partialPath, resp.StatusCode)
 	if err != nil {
 		return nil, err
 	}
@@ -92,8 +69,90 @@ func (d *Downloader) DownloadModel(user, repo, branch, filename string, destPath
 
 	d.startTime = time.Now()
 	d.lastUpdate = d.startTime
-	d.lastBytes = fileSize
+	d.lastBytes = existing
 
+	written, err := d.streamBody(resp.Body, file, existing, totalSize, sizeCap)
+	if err != nil {
+		_ = file.Close()
+		_ = os.Remove(partialPath)
+		return nil, fmt.Errorf("download %s: %w", filename, err)
+	}
+
+	file.Close()
+	if err := os.Rename(partialPath, destPath); err != nil {
+		return nil, err
+	}
+	return d.calculateProgress(written, totalSize), nil
+}
+
+// existingPartialSize returns the current size of a .partial file, or 0 if
+// none exists. Nonzero values cause the request to resume with Range.
+func existingPartialSize(partialPath string) int64 {
+	if info, err := os.Stat(partialPath); err == nil {
+		return info.Size()
+	}
+	return 0
+}
+
+// dispatchDownload issues the GET request, resuming from existing bytes
+// via a Range header when nonzero. Returns the response for the caller to
+// stream. Non-2xx statuses are surfaced as an error.
+func (d *Downloader) dispatchDownload(user, repo, branch, filename string, existing int64) (*http.Response, error) {
+	url := fmt.Sprintf("%s/%s/%s/resolve/%s/%s", baseURL, user, repo, branch, filename)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", version.UserAgent())
+	if d.client.token != "" {
+		req.Header.Set("Authorization", "Bearer "+d.client.token)
+	}
+	if existing > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", existing))
+	}
+
+	resp, err := d.client.downloadClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		resp.Body.Close()
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return resp, nil
+}
+
+// enforceSizeCap computes the tolerated cap (2× expected + 1 MiB) and
+// fails fast when the declared Content-Length already exceeds it. Returns
+// the cap value (0 when disabled) so the streaming path can enforce the
+// streamed-bytes check against the same number.
+func enforceSizeCap(filename string, expectedSize, totalSize int64) (int64, error) {
+	if expectedSize <= 0 {
+		return 0, nil
+	}
+	cap := expectedSize*2 + (1 << 20)
+	if totalSize > cap {
+		return 0, fmt.Errorf("download %s: declared %d exceeds cap of %d (expected %d)", filename, totalSize, cap, expectedSize)
+	}
+	return cap, nil
+}
+
+// openDownloadFile opens the .partial file for the download, choosing
+// truncate vs. append based on whether we got a full or partial response.
+func openDownloadFile(partialPath string, statusCode int) (*os.File, error) {
+	flags := os.O_CREATE | os.O_WRONLY
+	if statusCode == http.StatusOK {
+		flags |= os.O_TRUNC
+	} else {
+		flags |= os.O_APPEND
+	}
+	return os.OpenFile(partialPath, flags, 0644)
+}
+
+// streamBody writes resp.Body to file, enforcing the per-file size cap via
+// LimitReader(cap+1) + post-stream byte count. A lying Content-Length
+// can't fill the disk because the LimitReader terminates at cap+1.
+func (d *Downloader) streamBody(body io.Reader, file io.Writer, existing, totalSize, sizeCap int64) (int64, error) {
 	var progressFn func(int64, int64)
 	if d.progress != nil {
 		progressFn = func(written, total int64) {
@@ -101,20 +160,17 @@ func (d *Downloader) DownloadModel(user, repo, branch, filename string, destPath
 			d.progress(p.Downloaded, p.Total, p.Speed, p.ETA)
 		}
 	}
-
-	written, err := fileutil.StreamBody(resp.Body, file, fileSize, totalSize, progressFn)
+	if sizeCap > 0 {
+		body = io.LimitReader(body, sizeCap+1)
+	}
+	written, err := fileutil.StreamBody(body, file, existing, totalSize, progressFn)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
-
-	file.Close()
-
-	if err := os.Rename(partialPath, destPath); err != nil {
-		return nil, err
+	if sizeCap > 0 && written > sizeCap {
+		return 0, fmt.Errorf("exceeded size cap of %d bytes", sizeCap)
 	}
-
-	progress := d.calculateProgress(written, totalSize)
-	return progress, nil
+	return written, nil
 }
 
 func (d *Downloader) calculateProgress(downloaded, total int64) *DownloadProgress {

--- a/internal/hf/download.go
+++ b/internal/hf/download.go
@@ -247,6 +247,10 @@ type ModelMetadata struct {
 type QuantMetadata struct {
 	LastUsed     time.Time `yaml:"last_used,omitempty"`
 	DownloadedAt time.Time `yaml:"downloaded_at,omitempty"`
+	// Backend identifies the runtime that serves this quant: "gguf" or "mlx".
+	// Empty in legacy metadata files — treat as "gguf" (the only kind lleme
+	// could pull before MLX support landed).
+	Backend string `yaml:"backend,omitempty"`
 }
 
 // GetMetadataPath returns the path to the metadata.yaml file for a model repo.
@@ -283,6 +287,48 @@ func SaveMetadata(user, repo string, meta *ModelMetadata) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0644)
+}
+
+// SetBackendKind records the runtime kind ("gguf" or "mlx") for a quant in
+// metadata.yaml. Called at pull time so the proxy can pick the right backend
+// without re-detecting the model format.
+func SetBackendKind(user, repo, quant, kind string) error {
+	meta, err := LoadMetadata(user, repo)
+	if err != nil {
+		return err
+	}
+
+	q := meta.Quants[quant]
+	q.Backend = kind
+	if q.DownloadedAt.IsZero() {
+		q.DownloadedAt = time.Now()
+	}
+	meta.Quants[quant] = q
+
+	return SaveMetadata(user, repo, meta)
+}
+
+// Known backend kinds as persisted in metadata.yaml. These identify the
+// on-disk model format; the proxy maps them to a concrete Runtime.
+const (
+	BackendGGUF = "gguf"
+	BackendMLX  = "mlx"
+)
+
+// GetBackendKind returns the recorded backend kind for a quant. A missing
+// metadata file or an empty `backend:` field resolves to "gguf" (the only
+// format lleme supported before MLX). I/O and parse errors are propagated
+// so callers can surface them instead of silently falling back.
+func GetBackendKind(user, repo, quant string) (string, error) {
+	meta, err := LoadMetadata(user, repo)
+	if err != nil {
+		return "", err
+	}
+	q, ok := meta.Quants[quant]
+	if !ok || q.Backend == "" {
+		return BackendGGUF, nil
+	}
+	return q.Backend, nil
 }
 
 // TouchLastUsed updates the last used timestamp for a model.

--- a/internal/hf/download.go
+++ b/internal/hf/download.go
@@ -123,19 +123,42 @@ func (d *Downloader) dispatchDownload(user, repo, branch, filename string, exist
 	return resp, nil
 }
 
-// enforceSizeCap computes the tolerated cap (2× expected + 1 MiB) and
+// sizeCapSlackBytes is the additive slack on top of 2× the declared size.
+// Covers minor server-side re-packing (shard boundary bytes, metadata
+// shuffles) without needing a precise match.
+const sizeCapSlackBytes = 1 << 20 // 1 MiB
+
+// maxExpectedSize is the largest declared size we'll accept before refusing
+// the download outright. Two reasons for the clamp:
+//  1. Overflow safety — `expectedSize*2 + slack` must stay within int64, and
+//     `sizeCap+1` (used by the LimitReader in streamBody) must too. Anything
+//     below (MaxInt64 − slack) / 2 is safe on both counts.
+//  2. Sanity — no model file legitimately approaches 4 EiB. A manifest
+//     claiming otherwise is malicious or corrupt; failing fast is better
+//     than trying to be clever. 1 TiB covers real LLM shards with 1000×
+//     headroom against today's largest open-weight models.
+const maxExpectedSize int64 = 1 << 40 // 1 TiB
+
+// enforceSizeCap computes the tolerated cap (2× expected + slack) and
 // fails fast when the declared Content-Length already exceeds it. Returns
 // the cap value (0 when disabled) so the streaming path can enforce the
-// streamed-bytes check against the same number.
+// streamed-bytes check against the same number. Refuses pathological
+// expectedSize values to keep the arithmetic and the LimitReader(cap+1)
+// bound inside int64.
 func enforceSizeCap(filename string, expectedSize, totalSize int64) (int64, error) {
 	if expectedSize <= 0 {
 		return 0, nil
 	}
-	cap := expectedSize*2 + (1 << 20)
-	if totalSize > cap {
-		return 0, fmt.Errorf("download %s: declared %d exceeds cap of %d (expected %d)", filename, totalSize, cap, expectedSize)
+	if expectedSize > maxExpectedSize {
+		return 0, fmt.Errorf("download %s: declared size %d exceeds sanity limit %d", filename, expectedSize, maxExpectedSize)
 	}
-	return cap, nil
+	// Safe from overflow because expectedSize ≤ maxExpectedSize (2^40);
+	// 2×2^40 + 1 MiB is well under MaxInt64 (~9.2×10^18).
+	sizeCap := expectedSize*2 + sizeCapSlackBytes
+	if totalSize > sizeCap {
+		return 0, fmt.Errorf("download %s: declared %d exceeds cap of %d (expected %d)", filename, totalSize, sizeCap, expectedSize)
+	}
+	return sizeCap, nil
 }
 
 // openDownloadFile opens the .partial file for the download, choosing

--- a/internal/hf/download_test.go
+++ b/internal/hf/download_test.go
@@ -244,6 +244,72 @@ func TestFindFirstSplitFileEmptyDir(t *testing.T) {
 	}
 }
 
+func TestBackendKindRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", oldHome)
+	os.Setenv("HOME", tmpDir)
+
+	user, repo, quant := "u", "r", "Q4_K_M"
+	if err := os.MkdirAll(GetModelPath(user, repo), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Unknown model → "gguf" as the legacy default.
+	got, err := GetBackendKind(user, repo, quant)
+	if err != nil {
+		t.Fatalf("GetBackendKind: %v", err)
+	}
+	if got != BackendGGUF {
+		t.Errorf("default kind = %q, want %q", got, BackendGGUF)
+	}
+
+	if err := SetBackendKind(user, repo, quant, BackendMLX); err != nil {
+		t.Fatalf("SetBackendKind: %v", err)
+	}
+	got, err = GetBackendKind(user, repo, quant)
+	if err != nil {
+		t.Fatalf("GetBackendKind: %v", err)
+	}
+	if got != BackendMLX {
+		t.Errorf("after set, kind = %q, want %q", got, BackendMLX)
+	}
+
+	// DownloadedAt auto-filled on first write.
+	meta, err := LoadMetadata(user, repo)
+	if err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	if meta.Quants[quant].DownloadedAt.IsZero() {
+		t.Error("DownloadedAt was not set")
+	}
+
+	// Overwriting kind should keep DownloadedAt.
+	first := meta.Quants[quant].DownloadedAt
+	if err := SetBackendKind(user, repo, quant, BackendGGUF); err != nil {
+		t.Fatalf("SetBackendKind: %v", err)
+	}
+	meta, _ = LoadMetadata(user, repo)
+	if !meta.Quants[quant].DownloadedAt.Equal(first) {
+		t.Error("DownloadedAt should not change on rewrite")
+	}
+
+	// Empty Backend in metadata still reports gguf.
+	q := meta.Quants[quant]
+	q.Backend = ""
+	meta.Quants[quant] = q
+	if err := SaveMetadata(user, repo, meta); err != nil {
+		t.Fatalf("SaveMetadata: %v", err)
+	}
+	got, err = GetBackendKind(user, repo, quant)
+	if err != nil {
+		t.Fatalf("GetBackendKind: %v", err)
+	}
+	if got != BackendGGUF {
+		t.Errorf("empty field kind = %q, want %q", got, BackendGGUF)
+	}
+}
+
 func TestFindModelFileSingleFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	oldHome := os.Getenv("HOME")

--- a/internal/hf/download_test.go
+++ b/internal/hf/download_test.go
@@ -311,6 +311,37 @@ func TestBackendKindRoundTrip(t *testing.T) {
 	}
 }
 
+func TestEnforceSizeCap(t *testing.T) {
+	cases := []struct {
+		name                    string
+		expectedSize, totalSize int64
+		wantCap                 int64
+		wantErr                 string
+	}{
+		{"disabled when expectedSize=0", 0, 1_000_000_000_000, 0, ""},
+		{"well within tolerance", 1_000_000, 1_500_000, 2*1_000_000 + (1 << 20), ""},
+		{"exactly at tolerance boundary", 1_000_000, 1_000_000*2 + (1 << 20), 1_000_000*2 + (1 << 20), ""},
+		{"over tolerance rejected", 1_000_000, 1_000_000 * 4, 0, "exceeds cap"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cap, err := enforceSizeCap("x.bin", tc.expectedSize, tc.totalSize)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+			if cap != tc.wantCap {
+				t.Errorf("cap = %d, want %d", cap, tc.wantCap)
+			}
+		})
+	}
+}
+
 func TestGetBackendKindRejectsUnknown(t *testing.T) {
 	tmpDir := t.TempDir()
 	oldHome := os.Getenv("HOME")

--- a/internal/hf/download_test.go
+++ b/internal/hf/download_test.go
@@ -322,6 +322,11 @@ func TestEnforceSizeCap(t *testing.T) {
 		{"well within tolerance", 1_000_000, 1_500_000, 2*1_000_000 + (1 << 20), ""},
 		{"exactly at tolerance boundary", 1_000_000, 1_000_000*2 + (1 << 20), 1_000_000*2 + (1 << 20), ""},
 		{"over tolerance rejected", 1_000_000, 1_000_000 * 4, 0, "exceeds cap"},
+		// Pathological expectedSize rejected before arithmetic — guards
+		// against int64 overflow in `expectedSize*2 + slack` and the
+		// downstream LimitReader(sizeCap+1) bound.
+		{"expectedSize above sanity limit rejected", maxExpectedSize + 1, 0, 0, "sanity limit"},
+		{"expectedSize at MaxInt64 rejected", 1<<62 + 1, 0, 0, "sanity limit"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/hf/download_test.go
+++ b/internal/hf/download_test.go
@@ -3,6 +3,7 @@ package hf
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -307,6 +308,28 @@ func TestBackendKindRoundTrip(t *testing.T) {
 	}
 	if got != BackendGGUF {
 		t.Errorf("empty field kind = %q, want %q", got, BackendGGUF)
+	}
+}
+
+func TestGetBackendKindRejectsUnknown(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", oldHome)
+	os.Setenv("HOME", tmpDir)
+
+	user, repo, quant := "u", "r", "q"
+	if err := os.MkdirAll(GetModelPath(user, repo), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Manually plant a corrupt / tampered metadata.yaml with an unknown
+	// backend kind. Reading it must error rather than silently dispatch.
+	yaml := "quants:\n  q:\n    backend: evil\n"
+	if err := os.WriteFile(GetMetadataPath(user, repo), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := GetBackendKind(user, repo, quant)
+	if err == nil || !strings.Contains(err.Error(), "unrecognized backend kind") {
+		t.Errorf("err = %v, want unrecognized backend kind", err)
 	}
 }
 

--- a/internal/hf/inventory.go
+++ b/internal/hf/inventory.go
@@ -215,23 +215,27 @@ func hasGGUFInside(dir string) bool {
 	return false
 }
 
-// dirSize sums the sizes of regular files directly inside dir (non-recursive).
-// Both GGUF split trees and MLX trees are flat, so recursive walking would
-// just be overhead.
+// dirSize recursively sums the sizes of every regular file under dir.
+// GGUF split trees are flat, but MLX pulls preserve the HuggingFace tree
+// layout (e.g. `snapshots/<rev>/config.json`) via binaryrelease.SafeJoin,
+// so a flat scan would undercount MLX model sizes in list / remove / status
+// output. Symlinks are not followed; unreadable entries are skipped.
 func dirSize(dir string) int64 {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return 0
-	}
 	var total int64
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
+	_ = filepath.WalkDir(dir, func(_ string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
 		}
-		if info, err := e.Info(); err == nil {
-			total += info.Size()
+		if !d.Type().IsRegular() {
+			return nil
 		}
-	}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		total += info.Size()
+		return nil
+	})
 	return total
 }
 

--- a/internal/hf/inventory.go
+++ b/internal/hf/inventory.go
@@ -1,0 +1,264 @@
+package hf
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/nchapman/lleme/internal/config"
+)
+
+// loadMetadataFrom is the testable sibling of LoadMetadata that reads from
+// an explicit path rather than deriving one from config.ModelsPath(). nil
+// return is the "no metadata file" signal, which the caller treats as a
+// valid pre-metadata install.
+func loadMetadataFrom(path string) *ModelMetadata {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var meta ModelMetadata
+	if err := yaml.Unmarshal(data, &meta); err != nil {
+		return nil
+	}
+	if meta.Quants == nil {
+		meta.Quants = make(map[string]QuantMetadata)
+	}
+	return &meta
+}
+
+// LocalModel describes a downloaded model ready to serve. It's the
+// backend-neutral entry that `lleme list` and `lleme remove` work against.
+// Path is the file (single GGUF) or directory (split GGUF, MLX tree) the
+// server will be pointed at; Size is the on-disk total, including split
+// shards and sibling tokenizer files for MLX.
+type LocalModel struct {
+	User     string
+	Repo     string
+	Quant    string
+	Backend  string // BackendGGUF | BackendMLX
+	Path     string
+	Size     int64
+	LastUsed time.Time
+}
+
+// ListLocalModels enumerates everything pullable from ~/.lleme/models/.
+// Source of truth is metadata.yaml; any repo without one (legacy install,
+// manual dump) is still picked up via the .gguf fallback scan so users
+// don't lose visibility after upgrading.
+func ListLocalModels() ([]LocalModel, error) {
+	return ListLocalModelsInDir(config.ModelsPath())
+}
+
+// ListLocalModelsInDir is the testable form of ListLocalModels that walks an
+// explicit modelsDir rather than the configured one. Exported for tests and
+// tools; production code calls ListLocalModels.
+func ListLocalModelsInDir(modelsDir string) ([]LocalModel, error) {
+	entries, err := os.ReadDir(modelsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read models dir: %w", err)
+	}
+
+	var models []LocalModel
+	for _, userEntry := range entries {
+		if !userEntry.IsDir() {
+			continue
+		}
+		user := userEntry.Name()
+		userDir := filepath.Join(modelsDir, user)
+
+		repoEntries, err := os.ReadDir(userDir)
+		if err != nil {
+			continue
+		}
+		for _, repoEntry := range repoEntries {
+			if !repoEntry.IsDir() {
+				continue
+			}
+			repo := repoEntry.Name()
+			models = append(models, listRepoQuants(modelsDir, user, repo)...)
+		}
+	}
+	return models, nil
+}
+
+// listRepoQuants returns every quant present for a single user/repo pair.
+// Uses metadata.yaml when present (authoritative for backend kind), falls
+// back to scanning .gguf files so pre-metadata installs stay visible.
+func listRepoQuants(modelsDir, user, repo string) []LocalModel {
+	repoDir := filepath.Join(modelsDir, user, repo)
+	meta := loadMetadataFrom(filepath.Join(repoDir, "metadata.yaml"))
+	seen := make(map[string]bool)
+	var out []LocalModel
+
+	if meta != nil {
+		for quant, q := range meta.Quants {
+			kind := q.Backend
+			if kind == "" {
+				kind = BackendGGUF
+			}
+			if m, ok := resolveLocalModel(repoDir, user, repo, quant, kind, q.LastUsed); ok {
+				out = append(out, m)
+				seen[quant] = true
+			}
+		}
+	}
+
+	// Fallback: a repo without metadata.yaml (or with a quant on disk the
+	// metadata never learned about) — scan for .gguf files the way list
+	// used to before metadata existed.
+	for _, q := range scanLegacyGGUFQuants(repoDir) {
+		if seen[q] {
+			continue
+		}
+		if m, ok := resolveLocalModel(repoDir, user, repo, q, BackendGGUF, time.Time{}); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// resolveLocalModel fills in Path, Size, and LastUsed for a quant of the
+// given backend kind under repoDir. Returns (_, false) if nothing is on
+// disk for it. repoDir is supplied so the function is testable against an
+// arbitrary models tree instead of the configured one.
+func resolveLocalModel(repoDir, user, repo, quant, kind string, lastUsed time.Time) (LocalModel, bool) {
+	m := LocalModel{User: user, Repo: repo, Quant: quant, Backend: kind, LastUsed: lastUsed}
+	switch kind {
+	case BackendMLX:
+		dir := filepath.Join(repoDir, quant)
+		info, err := os.Stat(dir)
+		if err != nil || !info.IsDir() {
+			return m, false
+		}
+		m.Path = dir
+		m.Size = dirSize(dir)
+	default: // BackendGGUF or empty/unknown — treat as GGUF
+		singlePath := filepath.Join(repoDir, quant+".gguf")
+		if info, err := os.Stat(singlePath); err == nil && !info.IsDir() {
+			m.Path = singlePath
+			m.Size = info.Size()
+			if mmproj, err := os.Stat(filepath.Join(repoDir, quant+"-mmproj.gguf")); err == nil {
+				m.Size += mmproj.Size()
+			}
+			break
+		}
+		splitDir := filepath.Join(repoDir, quant)
+		if info, err := os.Stat(splitDir); err == nil && info.IsDir() {
+			m.Path = splitDir
+			m.Size = dirSize(splitDir)
+			break
+		}
+		return m, false
+	}
+	if m.LastUsed.IsZero() {
+		if info, err := os.Stat(m.Path); err == nil {
+			m.LastUsed = info.ModTime()
+		}
+	}
+	return m, true
+}
+
+// scanLegacyGGUFQuants discovers quants for a repo with no metadata.yaml.
+// Only invoked as a fallback, so it stays narrowly focused on the GGUF
+// single-file and split-dir layouts that preceded metadata tracking.
+func scanLegacyGGUFQuants(repoDir string) []string {
+	entries, err := os.ReadDir(repoDir)
+	if err != nil {
+		return nil
+	}
+
+	var out []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			// Split model stored under user/repo/<quant>/.
+			if hasGGUFInside(filepath.Join(repoDir, name)) {
+				out = append(out, name)
+			}
+			continue
+		}
+		if !strings.HasSuffix(name, ".gguf") {
+			continue
+		}
+		if IsMMProjFileName(name) {
+			continue
+		}
+		out = append(out, strings.TrimSuffix(name, ".gguf"))
+	}
+	return out
+}
+
+func hasGGUFInside(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".gguf") {
+			return true
+		}
+	}
+	return false
+}
+
+// dirSize sums the sizes of regular files directly inside dir (non-recursive).
+// Both GGUF split trees and MLX trees are flat, so recursive walking would
+// just be overhead.
+func dirSize(dir string) int64 {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	var total int64
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if info, err := e.Info(); err == nil {
+			total += info.Size()
+		}
+	}
+	return total
+}
+
+// RemoveLocalModel deletes everything on disk for a single quant and
+// tidies up empty parent directories. Safe to call for either backend.
+func RemoveLocalModel(m LocalModel) error {
+	// Primary payload: file for a single GGUF, directory for split GGUF or MLX.
+	info, err := os.Stat(m.Path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", m.Path, err)
+	}
+	if info.IsDir() {
+		if err := os.RemoveAll(m.Path); err != nil {
+			return fmt.Errorf("remove %s: %w", m.Path, err)
+		}
+	} else {
+		if err := os.Remove(m.Path); err != nil {
+			return fmt.Errorf("remove %s: %w", m.Path, err)
+		}
+	}
+
+	// Associated per-quant files (best-effort — missing is fine).
+	_ = os.Remove(GetManifestFilePath(m.User, m.Repo, m.Quant))
+	_ = os.Remove(GetMMProjFilePath(m.User, m.Repo, m.Quant))
+
+	// Drop the quant entry from metadata.yaml so it stops appearing in list.
+	if meta, err := LoadMetadata(m.User, m.Repo); err == nil {
+		delete(meta.Quants, m.Quant)
+		if len(meta.Quants) == 0 {
+			_ = os.Remove(GetMetadataPath(m.User, m.Repo))
+		} else {
+			_ = SaveMetadata(m.User, m.Repo, meta)
+		}
+	}
+	return nil
+}

--- a/internal/hf/inventory.go
+++ b/internal/hf/inventory.go
@@ -103,6 +103,12 @@ func listRepoQuants(modelsDir, user, repo string) []LocalModel {
 			kind := q.Backend
 			if kind == "" {
 				kind = BackendGGUF
+			} else if validated, err := parseBackendKind(kind); err == nil {
+				kind = validated
+			} else {
+				// Unknown backend in metadata — skip rather than list with a
+				// bogus kind that downstream callers would have to guess at.
+				continue
 			}
 			if m, ok := resolveLocalModel(repoDir, user, repo, quant, kind, q.LastUsed); ok {
 				out = append(out, m)

--- a/internal/hf/inventory.go
+++ b/internal/hf/inventory.go
@@ -256,6 +256,7 @@ func RemoveLocalModel(m LocalModel) error {
 	// Associated per-quant files (best-effort — missing is fine).
 	_ = os.Remove(GetManifestFilePath(m.User, m.Repo, m.Quant))
 	_ = os.Remove(GetMMProjFilePath(m.User, m.Repo, m.Quant))
+	_ = os.Remove(GetMLXManifestFilePath(m.User, m.Repo, m.Quant))
 
 	// Drop the quant entry from metadata.yaml so it stops appearing in list.
 	if meta, err := LoadMetadata(m.User, m.Repo); err == nil {

--- a/internal/hf/inventory_test.go
+++ b/internal/hf/inventory_test.go
@@ -1,0 +1,98 @@
+package hf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	data := make([]byte, size)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListLocalModelsMixedBackends(t *testing.T) {
+	modelsDir := t.TempDir()
+
+	// GGUF single file with metadata.
+	gguf := filepath.Join(modelsDir, "bartowski", "gguf-model")
+	writeFile(t, filepath.Join(gguf, "Q4_K_M.gguf"), 100)
+	writeFile(t, filepath.Join(gguf, "metadata.yaml"),
+		0)
+	_ = os.WriteFile(filepath.Join(gguf, "metadata.yaml"),
+		[]byte("quants:\n  Q4_K_M:\n    backend: gguf\n"), 0644)
+
+	// MLX directory with metadata.
+	mlx := filepath.Join(modelsDir, "mlx-community", "qwen-4bit")
+	writeFile(t, filepath.Join(mlx, "4bit", "model.safetensors"), 200)
+	writeFile(t, filepath.Join(mlx, "4bit", "config.json"), 50)
+	_ = os.WriteFile(filepath.Join(mlx, "metadata.yaml"),
+		[]byte("quants:\n  4bit:\n    backend: mlx\n"), 0644)
+
+	// Legacy GGUF with no metadata at all — must still be listed.
+	legacy := filepath.Join(modelsDir, "legacy-user", "legacy-repo")
+	writeFile(t, filepath.Join(legacy, "Q8_0.gguf"), 75)
+
+	got, err := ListLocalModelsInDir(modelsDir)
+	if err != nil {
+		t.Fatalf("ListLocalModelsInDir: %v", err)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("got %d models, want 3: %+v", len(got), got)
+	}
+
+	byKey := func(m LocalModel) string { return m.User + "/" + m.Repo + ":" + m.Quant }
+	seen := map[string]LocalModel{}
+	for _, m := range got {
+		seen[byKey(m)] = m
+	}
+
+	if m, ok := seen["bartowski/gguf-model:Q4_K_M"]; !ok {
+		t.Error("missing GGUF entry")
+	} else if m.Backend != BackendGGUF {
+		t.Errorf("gguf backend = %q", m.Backend)
+	} else if m.Size != 100 {
+		t.Errorf("gguf size = %d, want 100", m.Size)
+	}
+
+	if m, ok := seen["mlx-community/qwen-4bit:4bit"]; !ok {
+		t.Error("missing MLX entry")
+	} else if m.Backend != BackendMLX {
+		t.Errorf("mlx backend = %q", m.Backend)
+	} else if m.Size != 250 {
+		t.Errorf("mlx size = %d, want 250 (sum of dir contents)", m.Size)
+	}
+
+	if m, ok := seen["legacy-user/legacy-repo:Q8_0"]; !ok {
+		t.Error("missing legacy entry (no metadata.yaml fallback broken)")
+	} else if m.Backend != BackendGGUF {
+		t.Errorf("legacy backend = %q, want gguf fallback", m.Backend)
+	}
+}
+
+func TestListLocalModelsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	got, err := ListLocalModelsInDir(dir)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %d", len(got))
+	}
+
+	// Missing dir is also fine (fresh install).
+	got, err = ListLocalModelsInDir(filepath.Join(dir, "does-not-exist"))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty for missing dir, got %d", len(got))
+	}
+}

--- a/internal/hf/inventory_test.go
+++ b/internal/hf/inventory_test.go
@@ -77,6 +77,37 @@ func TestListLocalModelsMixedBackends(t *testing.T) {
 	}
 }
 
+// Regression: MLX repos preserve the HuggingFace tree layout, so files
+// can sit under nested paths (e.g. snapshots/<rev>/model.safetensors).
+// dirSize must walk recursively or the reported model size undercounts.
+func TestListLocalModelsMLXNestedSizeRecursive(t *testing.T) {
+	modelsDir := t.TempDir()
+
+	repoDir := filepath.Join(modelsDir, "mlx-community", "nested-repo")
+	quantDir := filepath.Join(repoDir, "4bit")
+	// Flat files (tokenizer/config) at the quant root.
+	writeFile(t, filepath.Join(quantDir, "config.json"), 100)
+	writeFile(t, filepath.Join(quantDir, "tokenizer.json"), 200)
+	// Nested weight shard under a snapshots/<rev>/ tree, like HF serves.
+	writeFile(t, filepath.Join(quantDir, "snapshots", "abc123", "model.safetensors"), 5000)
+	writeFile(t, filepath.Join(quantDir, "snapshots", "abc123", "model.safetensors.index.json"), 300)
+
+	_ = os.WriteFile(filepath.Join(repoDir, "metadata.yaml"),
+		[]byte("quants:\n  4bit:\n    backend: mlx\n"), 0644)
+
+	got, err := ListLocalModelsInDir(modelsDir)
+	if err != nil {
+		t.Fatalf("ListLocalModelsInDir: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 model, got %d: %+v", len(got), got)
+	}
+	const wantSize = int64(100 + 200 + 5000 + 300)
+	if got[0].Size != wantSize {
+		t.Errorf("MLX nested size = %d, want %d (flat+nested files)", got[0].Size, wantSize)
+	}
+}
+
 func TestListLocalModelsEmpty(t *testing.T) {
 	dir := t.TempDir()
 	got, err := ListLocalModelsInDir(dir)

--- a/internal/hf/mlx.go
+++ b/internal/hf/mlx.go
@@ -1,6 +1,7 @@
 package hf
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/nchapman/lleme/internal/binaryrelease"
+	"github.com/nchapman/lleme/internal/fileutil"
 )
 
 // mlxQuantSuffix matches the quantization suffix on mlx-community repos
@@ -89,6 +91,146 @@ func ListMLXFiles(files []FileTree) []FileTree {
 	return out
 }
 
+// mlxManifestVersion is the schema version written into the MLX manifest.
+// Bump when the manifest shape changes incompatibly; existing callers can
+// reject or migrate old versions.
+const mlxManifestVersion = "1"
+
+// MLXManifest records what files were downloaded for an MLX quant. Paths
+// are relative to the quant directory; sizes are the Content-Length values
+// reported by HuggingFace. LFS OIDs would be more authoritative but the
+// tree API reports them inconsistently for non-LFS files — size-only
+// comparison catches the common case (HF re-upload with new weights) and
+// misses the rare one (content-identical, size-identical edit).
+type MLXManifest struct {
+	Version string            `json:"version"`
+	Files   []MLXManifestFile `json:"files"`
+}
+
+type MLXManifestFile struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+}
+
+// GetMLXManifestFilePath returns the sibling path where an MLX manifest is
+// stored. Lives beside the quant directory (not inside it) so the manifest
+// survives a "rm -rf" of just the model contents the same way GGUF manifests
+// do at `<quant>-manifest.json`.
+func GetMLXManifestFilePath(user, repo, quant string) string {
+	modelDir := GetModelPath(user, repo)
+	return filepath.Join(modelDir, quant+"-mlx-manifest.json")
+}
+
+// SaveMLXManifest writes manifest atomically.
+func SaveMLXManifest(user, repo, quant string, files []FileTree) error {
+	entries := make([]MLXManifestFile, 0, len(files))
+	for _, f := range files {
+		entries = append(entries, MLXManifestFile{Path: f.Path, Size: f.Size})
+	}
+	m := MLXManifest{Version: mlxManifestVersion, Files: entries}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal mlx manifest: %w", err)
+	}
+	path := GetMLXManifestFilePath(user, repo, quant)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("mkdir for mlx manifest: %w", err)
+	}
+	return fileutil.AtomicWriteFile(path, data, 0644)
+}
+
+// LoadMLXManifest reads a saved manifest. Returns (nil, nil) when absent
+// (pre-manifest pulls or a legacy install) so callers can fall back.
+func LoadMLXManifest(user, repo, quant string) (*MLXManifest, error) {
+	path := GetMLXManifestFilePath(user, repo, quant)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var m MLXManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse mlx manifest: %w", err)
+	}
+	return &m, nil
+}
+
+// CheckForUpdatesMLX reports whether a locally-pulled MLX quant matches the
+// remote tree. Returns (upToDate, saveManifest, remoteFiles, err):
+//   - upToDate: every required file exists locally with matching size.
+//   - saveManifest: true when we matched via the fallback path (all files
+//     present at expected sizes) but no manifest was recorded yet — the
+//     caller should persist one so the next check is a cheap JSON compare.
+//   - remoteFiles: the filtered MLX file tree from HuggingFace, so a caller
+//     that decides to re-download doesn't need to re-list.
+//
+// Mirrors the GGUF pair (CheckForUpdates + checkSizeFallback).
+func CheckForUpdatesMLX(client *Client, user, repo, quant string) (bool, bool, []FileTree, error) {
+	if client == nil {
+		return false, false, nil, fmt.Errorf("HuggingFace client is required")
+	}
+	files, err := client.ListFiles(user, repo, "main")
+	if err != nil {
+		return false, false, nil, fmt.Errorf("list files: %w", err)
+	}
+	mlxFiles := ListMLXFiles(files)
+	if len(mlxFiles) == 0 {
+		return false, false, mlxFiles, fmt.Errorf("no MLX files found in %s/%s", user, repo)
+	}
+
+	destDir := GetSplitModelDir(user, repo, quant)
+	manifest, err := LoadMLXManifest(user, repo, quant)
+	if err != nil {
+		return false, false, mlxFiles, err
+	}
+
+	if manifest != nil {
+		return mlxManifestMatches(destDir, mlxFiles, manifest), false, mlxFiles, nil
+	}
+	// Fallback: no manifest recorded. Check that every expected file is
+	// present with matching size. If so, signal saveManifest=true so the
+	// caller writes one and subsequent checks are fast.
+	return mlxFilesMatchDisk(destDir, mlxFiles), true, mlxFiles, nil
+}
+
+// mlxManifestMatches compares the recorded manifest against both the remote
+// tree and the local filesystem. Any divergence — remote file added or
+// resized, local file missing or resized — signals "not up to date".
+func mlxManifestMatches(destDir string, remote []FileTree, manifest *MLXManifest) bool {
+	recorded := make(map[string]int64, len(manifest.Files))
+	for _, f := range manifest.Files {
+		recorded[f.Path] = f.Size
+	}
+	if len(recorded) != len(remote) {
+		return false
+	}
+	for _, f := range remote {
+		size, ok := recorded[f.Path]
+		if !ok || size != f.Size {
+			return false
+		}
+		local, err := os.Stat(filepath.Join(destDir, f.Path))
+		if err != nil || local.Size() != f.Size {
+			return false
+		}
+	}
+	return true
+}
+
+// mlxFilesMatchDisk is the manifest-less fallback: every remote file must
+// exist locally with the advertised size.
+func mlxFilesMatchDisk(destDir string, remote []FileTree) bool {
+	for _, f := range remote {
+		local, err := os.Stat(filepath.Join(destDir, f.Path))
+		if err != nil || local.Size() != f.Size {
+			return false
+		}
+	}
+	return true
+}
+
 // PullMLXModel downloads all MLX artifacts for a repo into a per-quant
 // directory and records backend=mlx in metadata.yaml. The caller selects
 // quant (typically via MLXQuantFromRepo) so we can host multiple MLX
@@ -127,8 +269,6 @@ func PullMLXModel(client *Client, user, repo, quant string, progress func(PullPr
 		TotalSize: totalSize,
 	}
 
-	// TODO: add freshness check using HF file sizes / LFS OIDs so re-pulls
-	// can skip unchanged files (mirrors the GGUF checkSizeFallback path).
 	var (
 		downloaded int64
 		written    []string
@@ -173,6 +313,16 @@ func PullMLXModel(client *Client, user, repo, quant string, progress func(PullPr
 
 	if err := SetBackendKind(user, repo, quant, BackendMLX); err != nil {
 		return nil, fmt.Errorf("failed to record backend kind: %w", err)
+	}
+
+	// Persist the file manifest so subsequent `lleme pull` invocations can
+	// short-circuit via CheckForUpdatesMLX. Failure to write the manifest
+	// shouldn't undo a successful pull — the next pull just falls back to
+	// the size-check path.
+	if err := SaveMLXManifest(user, repo, quant, mlxFiles); err != nil {
+		// Best-effort: log would be ideal, but we don't import logs here.
+		// The next pull will try again.
+		_ = err
 	}
 
 	return result, nil

--- a/internal/hf/mlx.go
+++ b/internal/hf/mlx.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/nchapman/lleme/internal/binaryrelease"
 )
 
 // mlxQuantSuffix matches the quantization suffix on mlx-community repos
@@ -131,8 +133,21 @@ func PullMLXModel(client *Client, user, repo, quant string, progress func(PullPr
 		downloaded int64
 		written    []string
 	)
+	absDest, err := filepath.Abs(destDir)
+	if err != nil {
+		cleanupMLX(dirExisted, destDir, written)
+		return nil, fmt.Errorf("resolve destination: %w", err)
+	}
 	for _, f := range mlxFiles {
-		destPath := filepath.Join(destDir, f.Path)
+		// f.Path comes verbatim from the HuggingFace tree API — an attacker
+		// who controls the repo can return "../../.ssh/id_rsa". SafeJoin
+		// refuses absolute paths, .. traversal, and any join that escapes
+		// the model directory.
+		destPath, err := binaryrelease.SafeJoin(absDest, f.Path)
+		if err != nil {
+			cleanupMLX(dirExisted, destDir, written)
+			return nil, fmt.Errorf("reject MLX file %q: %w", f.Path, err)
+		}
 		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
 			cleanupMLX(dirExisted, destDir, written)
 			return nil, fmt.Errorf("failed to create subdir for %s: %w", f.Path, err)

--- a/internal/hf/mlx.go
+++ b/internal/hf/mlx.go
@@ -1,0 +1,202 @@
+package hf
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// mlxQuantSuffix matches the quantization suffix on mlx-community repos
+// (e.g. "-4bit", "-8bit", "-bf16", "-fp16"). Anchored so we only catch the
+// trailing token — avoids false matches inside repo names like "4bit-eval".
+var mlxQuantSuffix = regexp.MustCompile(`(?i)-((?:[0-9]+bit)|bf16|fp16|fp32)$`)
+
+// DetectFormat classifies a HuggingFace repo by file listing. It prefers
+// GGUF when both are present (historical default for lleme), so accidental
+// stragglers in an MLX conversion don't redirect the pull. Returns "" when
+// neither format is detectable.
+func DetectFormat(files []FileTree) string {
+	var hasGGUF, hasConfig, hasSafetensors bool
+	for _, f := range files {
+		name := filepath.Base(f.Path)
+		switch {
+		case strings.HasSuffix(name, ".gguf"):
+			hasGGUF = true
+		case name == "config.json":
+			hasConfig = true
+		case strings.HasSuffix(name, ".safetensors"):
+			hasSafetensors = true
+		}
+	}
+	switch {
+	case hasGGUF:
+		return BackendGGUF
+	case hasConfig && hasSafetensors:
+		return BackendMLX
+	default:
+		return ""
+	}
+}
+
+// MLXQuantFromRepo derives a quant label from the repo name's trailing
+// suffix (e.g. "Qwen3-4B-Instruct-4bit" → "4bit"). Falls back to "default"
+// when no suffix matches — some MLX conversions are unquantized.
+func MLXQuantFromRepo(repo string) string {
+	m := mlxQuantSuffix.FindStringSubmatch(repo)
+	if m == nil {
+		return "default"
+	}
+	return strings.ToLower(m[1])
+}
+
+// isMLXModelFile reports whether a file in an MLX repo is part of the
+// runtime artifact we need to serve it. Keeping this allow-listed avoids
+// pulling READMEs, eval data, and PyTorch-side weights we don't use.
+func isMLXModelFile(name string) bool {
+	switch name {
+	case "config.json",
+		"tokenizer.json",
+		"tokenizer.model",
+		"tokenizer_config.json",
+		"special_tokens_map.json",
+		"generation_config.json",
+		"chat_template.jinja",
+		"added_tokens.json",
+		"vocab.json",
+		"merges.txt",
+		"model.safetensors.index.json":
+		return true
+	}
+	return strings.HasSuffix(name, ".safetensors")
+}
+
+// ListMLXFiles filters a repo tree down to files required by the MLX
+// backend, in the order they appear in the tree.
+func ListMLXFiles(files []FileTree) []FileTree {
+	var out []FileTree
+	for _, f := range files {
+		if f.Type == "directory" {
+			continue
+		}
+		if isMLXModelFile(filepath.Base(f.Path)) {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// PullMLXModel downloads all MLX artifacts for a repo into a per-quant
+// directory and records backend=mlx in metadata.yaml. The caller selects
+// quant (typically via MLXQuantFromRepo) so we can host multiple MLX
+// variants of the same repo side-by-side.
+func PullMLXModel(client *Client, user, repo, quant string, progress func(PullProgress)) (*PullResult, error) {
+	if client == nil {
+		return nil, fmt.Errorf("HuggingFace client is required")
+	}
+
+	files, err := client.ListFiles(user, repo, "main")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list files: %w", err)
+	}
+
+	mlxFiles := ListMLXFiles(files)
+	if len(mlxFiles) == 0 {
+		return nil, fmt.Errorf("no MLX files found in %s/%s", user, repo)
+	}
+
+	destDir := GetSplitModelDir(user, repo, quant)
+	dirExisted := true
+	if _, err := os.Stat(destDir); os.IsNotExist(err) {
+		dirExisted = false
+	}
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create model directory: %w", err)
+	}
+
+	var totalSize int64
+	for _, f := range mlxFiles {
+		totalSize += f.Size
+	}
+
+	result := &PullResult{
+		ModelPath: destDir,
+		TotalSize: totalSize,
+	}
+
+	// TODO: add freshness check using HF file sizes / LFS OIDs so re-pulls
+	// can skip unchanged files (mirrors the GGUF checkSizeFallback path).
+	var (
+		downloaded int64
+		written    []string
+	)
+	for _, f := range mlxFiles {
+		destPath := filepath.Join(destDir, f.Path)
+		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+			cleanupMLX(dirExisted, destDir, written)
+			return nil, fmt.Errorf("failed to create subdir for %s: %w", f.Path, err)
+		}
+
+		progressFn := func(current, total int64) {
+			if progress != nil {
+				progress(PullProgress{
+					Phase:   "download",
+					Current: downloaded + current,
+					Total:   totalSize,
+				})
+			}
+		}
+
+		if err := downloadFromHF(client, user, repo, &ManifestFile{RFilename: f.Path, Size: f.Size}, destPath, progressFn); err != nil {
+			cleanupMLX(dirExisted, destDir, written)
+			return nil, fmt.Errorf("download %s: %w", f.Path, err)
+		}
+		written = append(written, destPath)
+		downloaded += f.Size
+	}
+
+	if err := SetBackendKind(user, repo, quant, BackendMLX); err != nil {
+		return nil, fmt.Errorf("failed to record backend kind: %w", err)
+	}
+
+	return result, nil
+}
+
+// cleanupMLX undoes a partial pull. If the destination directory didn't
+// exist before this pull, we remove the whole thing; otherwise we only
+// delete files we wrote this session so a previous good copy survives.
+func cleanupMLX(dirExisted bool, destDir string, written []string) {
+	if !dirExisted {
+		os.RemoveAll(destDir)
+		return
+	}
+	for _, p := range written {
+		os.Remove(p)
+	}
+}
+
+// PullMLXModelWithProgress is the progress-bar-aware wrapper around
+// PullMLXModel, mirroring PullModelWithProgressFactory for GGUF.
+func PullMLXModelWithProgress(client *Client, user, repo, quant string, factory ProgressDisplayFactory) (*PullResult, error) {
+	var tracker *phaseTracker
+	if factory != nil {
+		tracker = &phaseTracker{factory: factory}
+	}
+
+	result, err := PullMLXModel(client, user, repo, quant, func(p PullProgress) {
+		if tracker == nil {
+			return
+		}
+		if p.Phase != tracker.phase {
+			tracker.transition(p.Phase, p.Total)
+		}
+		tracker.update(p.Current, p.Total)
+	})
+
+	if tracker != nil {
+		tracker.done(err)
+	}
+
+	return result, err
+}

--- a/internal/hf/mlx_test.go
+++ b/internal/hf/mlx_test.go
@@ -1,0 +1,141 @@
+package hf
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectFormat(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []FileTree
+		want  string
+	}{
+		{
+			name: "gguf preferred over mlx when both present",
+			files: []FileTree{
+				{Path: "config.json", Type: "file"},
+				{Path: "model.safetensors", Type: "file"},
+				{Path: "model.Q4_K_M.gguf", Type: "file"},
+			},
+			want: BackendGGUF,
+		},
+		{
+			name: "mlx detected from config and safetensors",
+			files: []FileTree{
+				{Path: "config.json", Type: "file"},
+				{Path: "tokenizer.json", Type: "file"},
+				{Path: "model.safetensors", Type: "file"},
+			},
+			want: BackendMLX,
+		},
+		{
+			name: "gguf only",
+			files: []FileTree{
+				{Path: "llama.Q8_0.gguf", Type: "file"},
+			},
+			want: BackendGGUF,
+		},
+		{
+			name: "config without safetensors is unknown",
+			files: []FileTree{
+				{Path: "config.json", Type: "file"},
+				{Path: "pytorch_model.bin", Type: "file"},
+			},
+			want: "",
+		},
+		{
+			name:  "empty repo is unknown",
+			files: nil,
+			want:  "",
+		},
+		{
+			name: "config.json in subdir still counts",
+			files: []FileTree{
+				{Path: "snapshots/abc/config.json", Type: "file"},
+				{Path: "snapshots/abc/model.safetensors", Type: "file"},
+			},
+			want: BackendMLX,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectFormat(tt.files); got != tt.want {
+				t.Errorf("DetectFormat() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMLXQuantFromRepo(t *testing.T) {
+	tests := []struct {
+		repo string
+		want string
+	}{
+		{"Qwen3-4B-Instruct-4bit", "4bit"},
+		{"Llama-3-8B-8bit", "8bit"},
+		{"Mistral-7B-bf16", "bf16"},
+		{"Phi-3-mini-fp16", "fp16"},
+		{"Gemma-2-9B-it", "default"},
+		{"Some-Model-4bit-eval", "default"}, // not anchored at end
+		{"Qwen3-4B-Instruct-4BIT", "4bit"},  // case-insensitive
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.repo, func(t *testing.T) {
+			if got := MLXQuantFromRepo(tt.repo); got != tt.want {
+				t.Errorf("MLXQuantFromRepo(%q) = %q, want %q", tt.repo, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestListMLXFiles(t *testing.T) {
+	files := []FileTree{
+		{Path: "README.md", Type: "file"},
+		{Path: "config.json", Type: "file"},
+		{Path: "tokenizer.json", Type: "file"},
+		{Path: "model-00001-of-00002.safetensors", Type: "file"},
+		{Path: "model-00002-of-00002.safetensors", Type: "file"},
+		{Path: "model.safetensors.index.json", Type: "file"},
+		{Path: "pytorch_model.bin", Type: "file"},
+		{Path: "assets", Type: "directory"},
+		{Path: "special_tokens_map.json", Type: "file"},
+	}
+
+	got := ListMLXFiles(files)
+	wantPaths := map[string]bool{
+		"config.json":                      true,
+		"tokenizer.json":                   true,
+		"model-00001-of-00002.safetensors": true,
+		"model-00002-of-00002.safetensors": true,
+		"model.safetensors.index.json":     true,
+		"special_tokens_map.json":          true,
+	}
+	if len(got) != len(wantPaths) {
+		t.Fatalf("got %d files, want %d: %+v", len(got), len(wantPaths), got)
+	}
+	for _, f := range got {
+		if !wantPaths[f.Path] {
+			t.Errorf("unexpected file in output: %s", f.Path)
+		}
+	}
+}
+
+func TestListMLXFilesPreservesNestedPaths(t *testing.T) {
+	files := []FileTree{
+		{Path: "snapshots/abc/config.json", Type: "file"},
+		{Path: "snapshots/abc/model.safetensors", Type: "file"},
+		{Path: "snapshots/abc/README.md", Type: "file"},
+	}
+	got := ListMLXFiles(files)
+	if len(got) != 2 {
+		t.Fatalf("got %d files, want 2: %+v", len(got), got)
+	}
+	for _, f := range got {
+		if !strings.HasPrefix(f.Path, "snapshots/abc/") {
+			t.Errorf("path not preserved: %s", f.Path)
+		}
+	}
+}

--- a/internal/hf/mlx_test.go
+++ b/internal/hf/mlx_test.go
@@ -1,6 +1,7 @@
 package hf
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -120,6 +121,20 @@ func TestListMLXFiles(t *testing.T) {
 		if !wantPaths[f.Path] {
 			t.Errorf("unexpected file in output: %s", f.Path)
 		}
+	}
+}
+
+// Path-traversal guard is enforced in PullMLXModel via binaryrelease.SafeJoin.
+// The behavior is covered by binaryrelease's own TestExtractTarGzRejects*
+// suite; here we just pin that the guard exists at the MLX call site so a
+// refactor can't accidentally regress it to a bare filepath.Join.
+func TestPullMLXModelUsesSafeJoin(t *testing.T) {
+	data, err := os.ReadFile("mlx.go")
+	if err != nil {
+		t.Fatalf("read mlx.go: %v", err)
+	}
+	if !strings.Contains(string(data), "binaryrelease.SafeJoin") {
+		t.Error("PullMLXModel must route HF-sourced paths through binaryrelease.SafeJoin")
 	}
 }
 

--- a/internal/hf/mlx_test.go
+++ b/internal/hf/mlx_test.go
@@ -2,6 +2,7 @@ package hf
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -135,6 +136,95 @@ func TestPullMLXModelUsesSafeJoin(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "binaryrelease.SafeJoin") {
 		t.Error("PullMLXModel must route HF-sourced paths through binaryrelease.SafeJoin")
+	}
+}
+
+// MLX manifest round-trip: write then read back matches the input.
+func TestMLXManifestRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	remote := []FileTree{
+		{Path: "config.json", Size: 100},
+		{Path: "model.safetensors", Size: 9001},
+	}
+	if err := SaveMLXManifest("u", "r", "4bit", remote); err != nil {
+		t.Fatalf("SaveMLXManifest: %v", err)
+	}
+	got, err := LoadMLXManifest("u", "r", "4bit")
+	if err != nil {
+		t.Fatalf("LoadMLXManifest: %v", err)
+	}
+	if got == nil || got.Version != mlxManifestVersion || len(got.Files) != 2 {
+		t.Fatalf("unexpected manifest: %+v", got)
+	}
+	if got.Files[1].Size != 9001 {
+		t.Errorf("size not round-tripped: %+v", got.Files[1])
+	}
+}
+
+// manifestMatches hits when sizes match, misses on drift, and misses when a
+// local file was deleted between pulls.
+func TestMLXManifestMatches(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(rel string, size int64) {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, make([]byte, size), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile("config.json", 100)
+	writeFile("model.safetensors", 9001)
+
+	remote := []FileTree{
+		{Path: "config.json", Size: 100},
+		{Path: "model.safetensors", Size: 9001},
+	}
+	manifest := &MLXManifest{
+		Version: mlxManifestVersion,
+		Files: []MLXManifestFile{
+			{Path: "config.json", Size: 100},
+			{Path: "model.safetensors", Size: 9001},
+		},
+	}
+
+	if !mlxManifestMatches(dir, remote, manifest) {
+		t.Error("matching remote + local + manifest should be up-to-date")
+	}
+
+	// Remote drift: one file resized upstream.
+	driftedRemote := []FileTree{
+		{Path: "config.json", Size: 100},
+		{Path: "model.safetensors", Size: 9999},
+	}
+	if mlxManifestMatches(dir, driftedRemote, manifest) {
+		t.Error("size drift in remote should not be up-to-date")
+	}
+
+	// Local drift: user deleted a file.
+	if err := os.Remove(filepath.Join(dir, "config.json")); err != nil {
+		t.Fatal(err)
+	}
+	if mlxManifestMatches(dir, remote, manifest) {
+		t.Error("missing local file should not be up-to-date")
+	}
+}
+
+// The fallback path (no manifest) matches when every remote file is present
+// locally with the expected size, and misses otherwise.
+func TestMLXFilesMatchDiskFallback(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), make([]byte, 50), 0644); err != nil {
+		t.Fatal(err)
+	}
+	remote := []FileTree{{Path: "config.json", Size: 50}}
+	if !mlxFilesMatchDisk(dir, remote) {
+		t.Error("exact-size match should return true")
+	}
+	remote[0].Size = 60
+	if mlxFilesMatchDisk(dir, remote) {
+		t.Error("size mismatch should return false")
 	}
 }
 

--- a/internal/hf/pull.go
+++ b/internal/hf/pull.go
@@ -256,7 +256,7 @@ func downloadFromHF(client *Client, user, repo string, file *ManifestFile, destP
 		}
 	})
 
-	if _, err := downloader.DownloadModel(user, repo, "main", file.RFilename, destPath); err != nil {
+	if _, err := downloader.DownloadModel(user, repo, "main", file.RFilename, destPath, file.Size); err != nil {
 		return fmt.Errorf("download %s/%s %s: %w", user, repo, file.RFilename, err)
 	}
 	return nil

--- a/internal/hf/pull.go
+++ b/internal/hf/pull.go
@@ -126,6 +126,12 @@ func PullModel(client *Client, user, repo string, quant Quantization, opts *Pull
 		return nil, err
 	}
 
+	// Record the backend runtime for this quant so the proxy can dispatch
+	// to the right server without re-detecting the model format later.
+	if err := SetBackendKind(user, repo, quant.Name, BackendGGUF); err != nil {
+		return nil, fmt.Errorf("failed to record backend kind: %w", err)
+	}
+
 	return result, nil
 }
 

--- a/internal/options/resolver.go
+++ b/internal/options/resolver.go
@@ -2,15 +2,23 @@ package options
 
 import (
 	"github.com/nchapman/lleme/internal/config"
+	"github.com/nchapman/lleme/internal/hf"
 	"github.com/nchapman/lleme/internal/logs"
 	"github.com/nchapman/lleme/internal/presets"
 )
 
 // Resolver resolves option values with priority: session > persona > preset > config.
+//
+// BackendKind selects which config-layer block to read at the bottom of the
+// precedence chain. Empty or BackendGGUF reads from Config.LlamaCpp.Options;
+// BackendMLX reads from Config.SwiftLM.Options. Unknown values fall back to
+// LlamaCpp for safety — legacy callers that construct a Resolver without a
+// kind continue to see the pre-SwiftLM behavior.
 type Resolver struct {
-	Persona *config.Persona
-	Preset  *presets.Preset
-	Config  *config.Config
+	Persona     *config.Persona
+	Preset      *presets.Preset
+	Config      *config.Config
+	BackendKind string
 }
 
 // NewResolver creates a new option resolver.
@@ -20,6 +28,15 @@ func NewResolver(persona *config.Persona, cfg *config.Config, preset *presets.Pr
 		Preset:  preset,
 		Config:  cfg,
 	}
+}
+
+// WithBackendKind sets the backend kind that drives which config block the
+// resolver reads at the config layer. Returns the receiver for chaining so
+// call sites stay compact. Pass hf.BackendMLX / hf.BackendGGUF; empty string
+// behaves as BackendGGUF.
+func (r *Resolver) WithBackendKind(kind string) *Resolver {
+	r.BackendKind = kind
+	return r
 }
 
 // ResolveFloat returns the first set value from: sessionVal, persona, preset, config.
@@ -57,10 +74,20 @@ func (r *Resolver) lookupRaw(key string) (any, string) {
 			return val, "preset"
 		}
 	}
-	if val, ok := r.Config.LlamaCpp.GetOption(key); ok {
+	if val, ok := r.configLayerOption(key); ok {
 		return val, "config"
 	}
 	return nil, ""
+}
+
+// configLayerOption reads the config-layer option for the resolver's
+// configured backend. Non-MLX kinds (empty, "gguf", anything unknown) read
+// from LlamaCpp so existing call sites behave identically until they opt in.
+func (r *Resolver) configLayerOption(key string) (any, bool) {
+	if r.BackendKind == hf.BackendMLX {
+		return r.Config.SwiftLM.GetOption(key)
+	}
+	return r.Config.LlamaCpp.GetOption(key)
 }
 
 // GetConfigFloatWithSource returns the first set float value from persona, preset, or config,

--- a/internal/options/resolver_test.go
+++ b/internal/options/resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/nchapman/lleme/internal/config"
+	"github.com/nchapman/lleme/internal/hf"
 	"github.com/nchapman/lleme/internal/presets"
 )
 
@@ -323,6 +324,53 @@ func TestWithSourceReportsCorrectLayer(t *testing.T) {
 		v, source := r.GetConfigFloatWithSource("nope")
 		if v != 0 || source != "" {
 			t.Errorf("got (%v, %q), want (0, \"\")", v, source)
+		}
+	})
+}
+
+// The config layer is backend-scoped: an MLX resolver reads swiftlm.options,
+// a gguf resolver reads llamacpp.options, and neither cross-reads. Guards
+// against regressions to the pre-fix behavior where llamacpp.options always
+// won the config layer for both backends.
+func TestResolver_ConfigLayerBackendScoped(t *testing.T) {
+	cfg := &config.Config{
+		LlamaCpp: config.LlamaCpp{Options: map[string]any{"temp": 0.1}},
+		SwiftLM:  config.SwiftLM{Options: map[string]any{"temp": 0.9}},
+	}
+
+	t.Run("mlx reads swiftlm.options", func(t *testing.T) {
+		r := NewResolver(nil, cfg, nil).WithBackendKind(hf.BackendMLX)
+		v, source := r.GetConfigFloatWithSource("temp")
+		if v != 0.9 || source != "config" {
+			t.Errorf("mlx got (%v, %q), want (0.9, \"config\")", v, source)
+		}
+	})
+
+	t.Run("gguf reads llamacpp.options", func(t *testing.T) {
+		r := NewResolver(nil, cfg, nil).WithBackendKind(hf.BackendGGUF)
+		v, source := r.GetConfigFloatWithSource("temp")
+		if v != 0.1 || source != "config" {
+			t.Errorf("gguf got (%v, %q), want (0.1, \"config\")", v, source)
+		}
+	})
+
+	t.Run("empty kind defaults to llamacpp (legacy callers)", func(t *testing.T) {
+		r := NewResolver(nil, cfg, nil)
+		v, source := r.GetConfigFloatWithSource("temp")
+		if v != 0.1 || source != "config" {
+			t.Errorf("legacy got (%v, %q), want (0.1, \"config\")", v, source)
+		}
+	})
+
+	t.Run("mlx does not cross-read llamacpp when swiftlm missing key", func(t *testing.T) {
+		mlxOnly := &config.Config{
+			LlamaCpp: config.LlamaCpp{Options: map[string]any{"temp": 0.1}},
+			SwiftLM:  config.SwiftLM{Options: map[string]any{}},
+		}
+		r := NewResolver(nil, mlxOnly, nil).WithBackendKind(hf.BackendMLX)
+		v, source := r.GetConfigFloatWithSource("temp")
+		if v != 0 || source != "" {
+			t.Errorf("mlx must not cross-read: got (%v, %q), want (0, \"\")", v, source)
 		}
 	})
 }

--- a/internal/presets/data/README.md
+++ b/internal/presets/data/README.md
@@ -18,7 +18,25 @@ options:
   min-p: 0.0
 ```
 
-Keys under `options` mirror `llama-server` CLI flags in kebab-case (`--temp` → `temp`, `--top-k` → `top-k`, `--presence-penalty` → `presence-penalty`, etc.). Unknown keys are passed through to the server verbatim.
+Keys under `options` mirror `llama-server` CLI flags in kebab-case (`--temp` → `temp`, `--top-k` → `top-k`, `--presence-penalty` → `presence-penalty`, etc.). llama-server passes unknown keys through verbatim; SwiftLM (MLX) drops anything it doesn't recognize.
+
+### Backend-specific overrides
+
+Add optional `llamacpp:` or `swiftlm:` sub-blocks when a recommendation applies to only one backend:
+
+```yaml
+options:
+  temp: 0.6              # shared — both backends get this
+  top-p: 0.95
+llamacpp:
+  options:
+    mirostat: 2          # llama.cpp only
+swiftlm:
+  options:
+    turbo-kv: true       # SwiftLM only
+```
+
+Backend-specific options layer on top of the shared `options:` map for the matching runtime. An MLX load of the preset above receives `temp`, `top-p`, and `turbo-kv`; a GGUF load receives `temp`, `top-p`, and `mirostat`.
 
 ## Match patterns
 

--- a/internal/presets/presets.go
+++ b/internal/presets/presets.go
@@ -106,11 +106,13 @@ func Load() ([]*Preset, error) {
 	return presets, nil
 }
 
-// MergeServerOptions builds a server options map layered for the given
-// backend kind: preset shared → preset backend-specific → persona shared
-// → persona backend-specific. Later wins. Returns nil if every layer is
-// empty. kind should be hf.BackendGGUF or hf.BackendMLX; any other value
-// falls back to the shared layers only.
+// MergeServerOptions builds a server options map for the given backend kind.
+// It layers preset options (shared then backend-specific, via GetOptions)
+// under the caller-supplied personaOpts, which should already be resolved
+// for the same kind via Persona.GetServerOptions. Persona keys win on
+// conflict. Returns nil if both inputs are empty. kind should be
+// hf.BackendGGUF or hf.BackendMLX; any other value drops the preset's
+// backend-specific layer and uses its shared options only.
 func MergeServerOptions(preset *Preset, personaOpts map[string]any, kind string) map[string]any {
 	presetOpts := preset.GetOptions(kind)
 	if presetOpts == nil && personaOpts == nil {

--- a/internal/presets/presets.go
+++ b/internal/presets/presets.go
@@ -8,6 +8,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/nchapman/lleme/internal/hf"
 	"github.com/nchapman/lleme/internal/logs"
 )
 
@@ -61,9 +62,9 @@ func (p *Preset) GetOptions(kind string) map[string]any {
 
 func (p *Preset) backendOptions(kind string) map[string]any {
 	switch kind {
-	case "gguf":
+	case hf.BackendGGUF:
 		return p.LlamaCpp.Options
-	case "mlx":
+	case hf.BackendMLX:
 		return p.SwiftLM.Options
 	}
 	return nil

--- a/internal/presets/presets.go
+++ b/internal/presets/presets.go
@@ -11,26 +11,62 @@ import (
 	"github.com/nchapman/lleme/internal/logs"
 )
 
+// PresetBackendSection holds runtime-specific option overrides. When set,
+// these layer on top of Preset.Options for the matching backend only.
+type PresetBackendSection struct {
+	Options map[string]any `yaml:"options,omitempty"`
+}
+
 // Preset holds curated inference settings for a model family.
+//
+// Options layering (per backend) is:
+//
+//	shared Options → backend-specific Options (later wins)
+//
+// so the common Qwen3 sampling defaults can live under the top-level
+// `options:` and backend-specific knobs (mirostat for llama.cpp, turbo-kv
+// for SwiftLM) sit under their respective sub-blocks without affecting the
+// other runtime.
 type Preset struct {
-	Name    string         `yaml:"name"`
-	Source  string         `yaml:"source"`
-	Match   []string       `yaml:"match"`
-	Options map[string]any `yaml:"options"`
+	Name     string               `yaml:"name"`
+	Source   string               `yaml:"source"`
+	Match    []string             `yaml:"match"`
+	Options  map[string]any       `yaml:"options"`
+	LlamaCpp PresetBackendSection `yaml:"llamacpp,omitempty"`
+	SwiftLM  PresetBackendSection `yaml:"swiftlm,omitempty"`
 
 	filename string // set by Load, used for deterministic sort
 }
 
-// GetOptions returns a shallow copy of the preset's options map.
-func (p *Preset) GetOptions() map[string]any {
-	if p == nil || len(p.Options) == 0 {
+// GetOptions returns a shallow copy of the preset's options, layered for
+// the given backend kind (hf.BackendGGUF / hf.BackendMLX). An empty kind
+// applies only the shared Options map.
+func (p *Preset) GetOptions(kind string) map[string]any {
+	if p == nil {
 		return nil
 	}
-	out := make(map[string]any, len(p.Options))
+	specific := p.backendOptions(kind)
+	if len(p.Options) == 0 && len(specific) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(p.Options)+len(specific))
 	for k, v := range p.Options {
 		out[k] = v
 	}
+	for k, v := range specific {
+		out[k] = v
+	}
 	return out
+}
+
+func (p *Preset) backendOptions(kind string) map[string]any {
+	switch kind {
+	case "gguf":
+		return p.LlamaCpp.Options
+	case "mlx":
+		return p.SwiftLM.Options
+	}
+	return nil
 }
 
 // Load parses all embedded *.yaml preset files, sorted alphabetically by filename.
@@ -70,14 +106,17 @@ func Load() ([]*Preset, error) {
 	return presets, nil
 }
 
-// MergeServerOptions builds a server options map merging preset and persona,
-// with persona taking priority. Returns nil if both have no options.
-func MergeServerOptions(preset *Preset, personaOpts map[string]any) map[string]any {
-	presetOpts := preset.GetOptions()
+// MergeServerOptions builds a server options map layered for the given
+// backend kind: preset shared → preset backend-specific → persona shared
+// → persona backend-specific. Later wins. Returns nil if every layer is
+// empty. kind should be hf.BackendGGUF or hf.BackendMLX; any other value
+// falls back to the shared layers only.
+func MergeServerOptions(preset *Preset, personaOpts map[string]any, kind string) map[string]any {
+	presetOpts := preset.GetOptions(kind)
 	if presetOpts == nil && personaOpts == nil {
 		return nil
 	}
-	merged := make(map[string]any)
+	merged := make(map[string]any, len(presetOpts)+len(personaOpts))
 	for k, v := range presetOpts {
 		merged[k] = v
 	}

--- a/internal/presets/presets_test.go
+++ b/internal/presets/presets_test.go
@@ -532,3 +532,19 @@ func TestMergeServerOptionsLayering(t *testing.T) {
 		t.Errorf("ctx-size = %v, want 8192 (from persona)", got["ctx-size"])
 	}
 }
+
+// Persona backend-specific options (already folded into personaOpts by the
+// caller via Persona.GetServerOptions(kind)) must win over preset's own
+// backend-specific layer. This is the load-bearing guarantee of the four-
+// layer precedence.
+func TestMergeServerOptionsPersonaBackendOverridesPresetBackend(t *testing.T) {
+	p := &Preset{
+		LlamaCpp: PresetBackendSection{Options: map[string]any{"mirostat": 2}},
+	}
+	personaOpts := map[string]any{"mirostat": 1} // simulates persona.SwiftLM already merged
+
+	got := MergeServerOptions(p, personaOpts, "gguf")
+	if got["mirostat"] != 1 {
+		t.Errorf("mirostat = %v, want 1 (persona backend beats preset backend)", got["mirostat"])
+	}
+}

--- a/internal/presets/presets_test.go
+++ b/internal/presets/presets_test.go
@@ -394,14 +394,14 @@ func TestRepoName(t *testing.T) {
 
 func TestMergeServerOptions(t *testing.T) {
 	t.Run("both nil returns nil", func(t *testing.T) {
-		if got := MergeServerOptions(nil, nil); got != nil {
+		if got := MergeServerOptions(nil, nil, ""); got != nil {
 			t.Errorf("expected nil, got %v", got)
 		}
 	})
 
 	t.Run("preset only", func(t *testing.T) {
 		p := &Preset{Options: map[string]any{"temp": 0.7, "top-k": 20}}
-		got := MergeServerOptions(p, nil)
+		got := MergeServerOptions(p, nil, "")
 		if got == nil {
 			t.Fatal("expected non-nil")
 		}
@@ -414,7 +414,7 @@ func TestMergeServerOptions(t *testing.T) {
 	})
 
 	t.Run("persona only", func(t *testing.T) {
-		got := MergeServerOptions(nil, map[string]any{"ctx-size": 4096})
+		got := MergeServerOptions(nil, map[string]any{"ctx-size": 4096}, "")
 		if got == nil {
 			t.Fatal("expected non-nil")
 		}
@@ -426,7 +426,7 @@ func TestMergeServerOptions(t *testing.T) {
 	t.Run("persona wins over preset on conflict", func(t *testing.T) {
 		p := &Preset{Options: map[string]any{"temp": 0.7, "top-k": 20}}
 		persona := map[string]any{"temp": 0.5, "ctx-size": 4096}
-		got := MergeServerOptions(p, persona)
+		got := MergeServerOptions(p, persona, "")
 		if got["temp"] != 0.5 {
 			t.Errorf("temp = %v, want 0.5 (persona wins)", got["temp"])
 		}
@@ -441,7 +441,7 @@ func TestMergeServerOptions(t *testing.T) {
 	t.Run("returned map is independent of inputs", func(t *testing.T) {
 		p := &Preset{Options: map[string]any{"temp": 0.7}}
 		persona := map[string]any{"top-k": 20}
-		got := MergeServerOptions(p, persona)
+		got := MergeServerOptions(p, persona, "")
 		got["injected"] = true
 		if _, ok := p.Options["injected"]; ok {
 			t.Error("mutation affected preset")
@@ -454,7 +454,7 @@ func TestMergeServerOptions(t *testing.T) {
 
 func TestGetOptions(t *testing.T) {
 	p := &Preset{Options: map[string]any{"temp": 0.7, "top-k": 20}}
-	got := p.GetOptions()
+	got := p.GetOptions("")
 	if got == nil {
 		t.Fatal("expected non-nil options")
 	}
@@ -465,7 +465,70 @@ func TestGetOptions(t *testing.T) {
 	}
 
 	var nilPreset *Preset
-	if nilPreset.GetOptions() != nil {
+	if nilPreset.GetOptions("") != nil {
 		t.Error("nil preset GetOptions should return nil")
+	}
+}
+
+func TestGetOptionsBackendSpecific(t *testing.T) {
+	p := &Preset{
+		Options:  map[string]any{"temp": 0.6, "top-p": 0.95},
+		LlamaCpp: PresetBackendSection{Options: map[string]any{"mirostat": 2, "temp": 0.5}},
+		SwiftLM:  PresetBackendSection{Options: map[string]any{"turbo-kv": true}},
+	}
+
+	// gguf: shared + llamacpp (llamacpp wins on conflict).
+	got := p.GetOptions("gguf")
+	if got["temp"] != 0.5 {
+		t.Errorf("gguf temp = %v, want 0.5 (llamacpp overrides shared)", got["temp"])
+	}
+	if got["top-p"] != 0.95 {
+		t.Errorf("gguf top-p = %v, want 0.95 (from shared)", got["top-p"])
+	}
+	if got["mirostat"] != 2 {
+		t.Errorf("gguf mirostat = %v, want 2", got["mirostat"])
+	}
+	if _, ok := got["turbo-kv"]; ok {
+		t.Error("gguf should not contain swiftlm-only turbo-kv")
+	}
+
+	// mlx: shared + swiftlm, no llamacpp bleed.
+	got = p.GetOptions("mlx")
+	if got["turbo-kv"] != true {
+		t.Errorf("mlx turbo-kv = %v, want true", got["turbo-kv"])
+	}
+	if _, ok := got["mirostat"]; ok {
+		t.Error("mlx should not contain llamacpp-only mirostat")
+	}
+	if got["temp"] != 0.6 {
+		t.Errorf("mlx temp = %v, want 0.6 (shared, no swiftlm override)", got["temp"])
+	}
+
+	// unknown/empty kind: shared only.
+	got = p.GetOptions("")
+	if _, ok := got["mirostat"]; ok {
+		t.Error("empty kind leaked llamacpp options")
+	}
+	if _, ok := got["turbo-kv"]; ok {
+		t.Error("empty kind leaked swiftlm options")
+	}
+}
+
+func TestMergeServerOptionsLayering(t *testing.T) {
+	p := &Preset{
+		Options:  map[string]any{"temp": 0.6},
+		LlamaCpp: PresetBackendSection{Options: map[string]any{"mirostat": 2}},
+	}
+	persona := map[string]any{"temp": 0.9, "ctx-size": 8192}
+
+	got := MergeServerOptions(p, persona, "gguf")
+	if got["temp"] != 0.9 {
+		t.Errorf("temp = %v, want 0.9 (persona wins)", got["temp"])
+	}
+	if got["mirostat"] != 2 {
+		t.Errorf("mirostat = %v, want 2 (from preset.llamacpp)", got["mirostat"])
+	}
+	if got["ctx-size"] != 8192 {
+		t.Errorf("ctx-size = %v, want 8192 (from persona)", got["ctx-size"])
 	}
 }

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -7,16 +7,36 @@ package proxy
 //
 // Scope for this pass:
 //   - Text content: full support (string or array of {type:"text", text:...}).
-//   - Image content: full support (base64 → OpenAI data URL).
+//   - Image content: full support (base64 → OpenAI data URL; accepted media
+//     types restricted to Anthropic's documented set).
 //   - Tool calling (request-level tools/tool_choice, plus tool_use and
 //     tool_result content blocks): rejected with a 400 because the two APIs
 //     disagree enough that a partial translation would silently misbehave.
 //     Will revisit when SwiftLM's tool-calling story firms up.
+//   - Non-text content blocks (document, thinking, redacted_thinking, etc.)
+//     rejected with a 400.
+//
+// Known limitations relative to Anthropic's public spec (by design for now):
+//   - message_start.usage.input_tokens is always 0 in streamed responses.
+//     OpenAI with stream_options.include_usage only reports prompt_tokens in
+//     the final chunk; backfilling message_start would require buffering the
+//     entire stream and break TTFT. Documented, tested.
+//   - stop_reason is never "stop_sequence" because OpenAI does not report
+//     which stop string matched. We map finish_reason="stop" to "end_turn".
+//   - OpenAI finish_reason="content_filter" maps to "end_turn" — Anthropic
+//     has no direct analog in the stop_reason enum.
+//   - Periodic ping events are not emitted; intermediaries that idle-close
+//     SSE connections may drop very long streams.
+//   - The anthropic-version request header is not enforced (local proxy).
+//   - Forward-compat: unknown top-level fields (service_tier, container,
+//     thinking, output_config, etc.) and cache_control hints on supported
+//     blocks are silently ignored rather than rejected.
 
 import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -133,12 +153,23 @@ type openAIUsage struct {
 	TotalTokens      int `json:"total_tokens"`
 }
 
-// openAIStreamChunk is a single SSE event body from /v1/chat/completions
+// openAIStreamChunk is a single SSE event body from /v1/chat/completions.
+// `Error` is present when a backend interrupts a stream with an error
+// payload (OpenAI convention: `{"error": {"message": "...", "type": "..."}}`).
+// Anthropic's equivalent is an `event: error` SSE event, which translateAnthropicStream
+// emits on demand.
 type openAIStreamChunk struct {
 	ID      string               `json:"id"`
 	Model   string               `json:"model"`
 	Choices []openAIStreamChoice `json:"choices"`
 	Usage   *openAIUsage         `json:"usage,omitempty"`
+	Error   *openAIStreamError   `json:"error,omitempty"`
+}
+
+type openAIStreamError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code,omitempty"`
 }
 
 type openAIStreamChoice struct {
@@ -418,7 +449,6 @@ type streamState struct {
 	flush            func()
 	messageID, model string
 	started          bool // emitted message_start + content_block_start
-	promptTokens     int
 	completionTokens int
 	stopReason       string
 }
@@ -464,16 +494,45 @@ func (s *streamState) ensureStarted() error {
 	if err != nil {
 		return err
 	}
+	// Anthropic's documented content_block_start carries a text block with
+	// an empty string. SDKs (notably the Python/TS accumulators) construct a
+	// TextBlock from this event and expect `text` to be present.
 	return s.writeEvent("content_block_start", map[string]any{
 		"type":          "content_block_start",
 		"index":         0,
-		"content_block": map[string]string{"type": "text"},
+		"content_block": map[string]string{"type": "text", "text": ""},
 	})
 }
 
+// errStreamAborted signals translateAnthropicStream that the upstream
+// reported an error mid-stream and an Anthropic error event has already
+// been emitted; the stream loop should stop cleanly.
+var errStreamAborted = fmt.Errorf("stream aborted by upstream error")
+
 func (s *streamState) applyChunk(chunk *openAIStreamChunk) error {
+	// Upstream signaled an error mid-stream. Translate to Anthropic's
+	// `event: error` and stop — further chunks would be semantically
+	// meaningless after an error.
+	if chunk.Error != nil {
+		errType := chunk.Error.Type
+		if errType == "" {
+			errType = string(AnthropicAPIError)
+		}
+		if err := s.writeEvent("error", map[string]any{
+			"type": "error",
+			"error": map[string]string{
+				"type":    errType,
+				"message": chunk.Error.Message,
+			},
+		}); err != nil {
+			return err
+		}
+		return errStreamAborted
+	}
 	if chunk.Usage != nil {
-		s.promptTokens = chunk.Usage.PromptTokens
+		// Only completion/output tokens are forwarded — message_delta.usage
+		// per spec is output-only (cumulative). prompt_tokens is known too
+		// late to backfill message_start, which is a documented limitation.
 		s.completionTokens = chunk.Usage.CompletionTokens
 	}
 	for _, c := range chunk.Choices {
@@ -512,6 +571,10 @@ func (s *streamState) finalize() error {
 	if stopReason == "" {
 		stopReason = "end_turn"
 	}
+	// Per Anthropic's spec, message_delta.usage is the cumulative running
+	// total and carries only output_tokens; input_tokens belongs in
+	// message_start.message.usage (which is zero today — see known
+	// limitations in the package comment).
 	if err := s.writeEvent("message_delta", map[string]any{
 		"type": "message_delta",
 		"delta": map[string]any{
@@ -519,7 +582,6 @@ func (s *streamState) finalize() error {
 			"stop_sequence": nil,
 		},
 		"usage": map[string]int{
-			"input_tokens":  s.promptTokens,
 			"output_tokens": s.completionTokens,
 		},
 	}); err != nil {
@@ -554,6 +616,12 @@ func translateAnthropicStream(w io.Writer, upstream io.Reader, messageID, model 
 			continue
 		}
 		if err := state.applyChunk(&chunk); err != nil {
+			if errors.Is(err, errStreamAborted) {
+				// Error event already emitted; don't tack on trailing
+				// message_delta/message_stop frames that would confuse
+				// the client about the final state.
+				return nil
+			}
 			return err
 		}
 	}
@@ -575,6 +643,13 @@ func countAnthropicTokens(body []byte) (int, error) {
 	var req anthropicMessagesRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return 0, newBadRequest("Failed to parse request body as JSON")
+	}
+
+	// Reject tool/tool_choice for the same reason /v1/messages does —
+	// and because tool schemas contribute meaningful token counts that
+	// our char-ratio approximation would silently undercount.
+	if rawJSONPresent(req.Tools) || rawJSONPresent(req.ToolChoice) {
+		return 0, newBadRequest("tools/tool_choice are not yet supported in /v1/messages/count_tokens")
 	}
 
 	var total int

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -5,45 +5,45 @@ package proxy
 // happens here so backends only need to speak OpenAI; this lets llama-server
 // and SwiftLM (which has no Anthropic endpoint) present a consistent surface.
 //
-// Scope for this pass:
+// Scope:
 //   - Text content: full support (string or array of {type:"text", text:...}).
-//   - Image content: base64 (media_type restricted to Anthropic's accepted set)
-//     and url sources both supported.
-//   - Tool calling (request-level tools/tool_choice, plus tool_use and
-//     tool_result content blocks): rejected with a 400 because the two APIs
-//     disagree enough that a partial translation would silently misbehave.
-//     Will revisit when SwiftLM's tool-calling story firms up. Reference
-//     implementation: llama.cpp's tools/server/server-common.cpp
-//     convert_anthropic_to_oai() shows the full mapping (tool_use →
-//     tool_calls, tool_result → role:tool, tool_choice {auto|any|tool} →
-//     {auto|required|{name:...}}).
-//   - Extended-thinking blocks (thinking, redacted_thinking) and document
-//     blocks: rejected with a 400. llama.cpp forwards thinking as
-//     reasoning_content on the OpenAI side and emits signature_delta on
-//     the Anthropic side — worth adopting once SwiftLM's thinking story is
-//     clear.
+//   - Image content: base64 with Anthropic's accepted media_type set. URL
+//     sources are rejected with a clear 400 because neither llama-server nor
+//     SwiftLM fetch URLs at request time; forwarding one would surface as an
+//     opaque backend error.
+//   - Tool calling: full round-trip. Request-level tools translate to OpenAI
+//     function tools; tool_choice {auto|any|tool|none} maps to OpenAI's
+//     {auto|required|function:{name}|none}; assistant tool_use blocks become
+//     message.tool_calls; user tool_result blocks split into role:"tool"
+//     messages. Responses with finish_reason=="tool_calls" translate back
+//     to Anthropic tool_use content blocks with stop_reason="tool_use".
+//   - Streaming: tool_call deltas accumulate per OpenAI tool index into their
+//     own Anthropic content_block index; function.arguments fragments become
+//     input_json_delta partial_json events that SDK accumulators reassemble.
+//   - Extended-thinking blocks (thinking, redacted_thinking): dropped rather
+//     than rejected. They're advisory; backends that don't understand them
+//     would reject the message. Document blocks remain rejected.
+//   - Error translation: upstream error types map to Anthropic's enum via
+//     normalizeAnthropicErrorType; upstream HTTP status codes map via
+//     anthropicErrorTypeForStatus. SDK consumers never see backend-specific
+//     error types leaking through.
 //
 // Known limitations relative to Anthropic's public spec (by design for now):
 //   - message_start.usage.input_tokens is always 0 in streamed responses.
 //     OpenAI with stream_options.include_usage only reports prompt_tokens in
 //     the final chunk; backfilling message_start would require buffering the
-//     entire stream and break TTFT. llama.cpp cheats by pre-tokenizing on
-//     the same process — we can't, without a separate tokenize round-trip.
-//   - stop_reason is never "stop_sequence" because OpenAI does not report
-//     which stop string matched. We map finish_reason="stop" to "end_turn".
-//   - OpenAI finish_reason="content_filter" maps to "end_turn" — Anthropic
-//     has no direct analog in the stop_reason enum.
+//     entire stream and break TTFT.
 //   - Periodic ping events are not emitted; intermediaries that idle-close
 //     SSE connections may drop very long streams.
 //   - cache_creation_input_tokens / cache_read_input_tokens are not emitted.
 //     Requires backend-side prompt-cache tracking we don't currently have.
 //   - count_tokens is a char-ratio approximation, not a real tokenize call.
-//     llama.cpp runs the actual tokenizer in-process; our proxy would need
-//     a backend round-trip (or to load a tokenizer) for parity.
+//     Tuned conservative (overcount) so context-budget planners don't
+//     under-request and hit a mid-stream context-window overflow.
 //   - The anthropic-version request header is not enforced (local proxy).
 //   - Forward-compat: unknown top-level fields (service_tier, container,
-//     thinking, output_config, etc.) and cache_control hints on supported
-//     blocks are silently ignored rather than rejected.
+//     output_config, etc.) and cache_control hints on supported blocks are
+//     silently ignored rather than rejected.
 
 import (
 	"bufio"
@@ -67,9 +67,15 @@ type anthropicMessagesRequest struct {
 	TopK          *int               `json:"top_k,omitempty"`
 	StopSequences []string           `json:"stop_sequences,omitempty"`
 	Stream        bool               `json:"stream,omitempty"`
-	Tools         json.RawMessage    `json:"tools,omitempty"`
-	ToolChoice    json.RawMessage    `json:"tool_choice,omitempty"`
-	Metadata      json.RawMessage    `json:"metadata,omitempty"` // ignored
+	Tools         []anthropicTool    `json:"tools,omitempty"`
+	ToolChoice    json.RawMessage    `json:"tool_choice,omitempty"` // object shape varies; parsed separately
+	Metadata      json.RawMessage    `json:"metadata,omitempty"`    // ignored
+}
+
+type anthropicTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema"`
 }
 
 type anthropicMessage struct {
@@ -77,11 +83,24 @@ type anthropicMessage struct {
 	Content json.RawMessage `json:"content"` // string or array of content blocks
 }
 
+// anthropicContentBlock intentionally models every block type we translate —
+// tool_use and tool_result are handled in message translation, so they need
+// their fields available here. Unused fields tolerate null/empty for block
+// types that don't carry them.
 type anthropicContentBlock struct {
 	Type   string                `json:"type"`
 	Text   string                `json:"text,omitempty"`
 	Source *anthropicImageSource `json:"source,omitempty"`
-	// tool_use / tool_result fields intentionally not modeled — rejected at request-parse time.
+
+	// tool_use (assistant-authored blocks)
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+
+	// tool_result (user-authored blocks)
+	ToolUseID   string          `json:"tool_use_id,omitempty"`
+	ToolContent json.RawMessage `json:"content,omitempty"`
+	ToolIsError bool            `json:"is_error,omitempty"`
 }
 
 type anthropicImageSource struct {
@@ -102,9 +121,15 @@ type anthropicMessagesResponse struct {
 	Usage        anthropicUsage             `json:"usage"`
 }
 
+// anthropicResponseContent carries either a text block or a tool_use block.
+// Fields are emitted conditionally via omitempty so text blocks don't leak
+// null tool fields and vice versa.
 type anthropicResponseContent struct {
-	Type string `json:"type"` // "text"
-	Text string `json:"text"`
+	Type  string          `json:"type"`
+	Text  string          `json:"text,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
 }
 
 type anthropicUsage struct {
@@ -124,6 +149,19 @@ type openAIChatRequest struct {
 	Stop          []string          `json:"stop,omitempty"`
 	Stream        bool              `json:"stream,omitempty"`
 	StreamOptions *openAIStreamOpts `json:"stream_options,omitempty"`
+	Tools         []openAITool      `json:"tools,omitempty"`
+	ToolChoice    json.RawMessage   `json:"tool_choice,omitempty"`
+}
+
+type openAITool struct {
+	Type     string             `json:"type"` // always "function"
+	Function openAIToolFunction `json:"function"`
+}
+
+type openAIToolFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters"`
 }
 
 // openAIStreamOpts controls streaming extensions we need. include_usage
@@ -134,8 +172,21 @@ type openAIStreamOpts struct {
 }
 
 type openAIMessage struct {
-	Role    string          `json:"role"`
-	Content json.RawMessage `json:"content"` // string or multimodal array
+	Role       string           `json:"role"`
+	Content    json.RawMessage  `json:"content,omitempty"` // string or multimodal array; may be absent for assistant tool_calls
+	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"` // set when Role == "tool"
+}
+
+type openAIToolCall struct {
+	ID       string                 `json:"id"`
+	Type     string                 `json:"type"` // always "function"
+	Function openAIToolCallFunction `json:"function"`
+}
+
+type openAIToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // JSON-serialized argument object
 }
 
 type openAIContentPart struct {
@@ -156,9 +207,14 @@ type openAIChatResponse struct {
 }
 
 type openAIChoice struct {
-	Index        int           `json:"index"`
-	Message      openAIMessage `json:"message"`
-	FinishReason string        `json:"finish_reason"`
+	Index   int           `json:"index"`
+	Message openAIMessage `json:"message"`
+	// llama-server extension: the stop_sequences entry that terminated
+	// generation. Populated when FinishReason == "stop" and the model hit a
+	// user-supplied stop string. Not part of the OpenAI spec; we forward it
+	// so Anthropic stop_sequence / stop_reason: "stop_sequence" work end-to-end.
+	StoppingWord string `json:"stopping_word,omitempty"`
+	FinishReason string `json:"finish_reason"`
 }
 
 type openAIUsage struct {
@@ -187,14 +243,32 @@ type openAIStreamError struct {
 }
 
 type openAIStreamChoice struct {
-	Index        int         `json:"index"`
-	Delta        openAIDelta `json:"delta"`
-	FinishReason *string     `json:"finish_reason"`
+	Index int         `json:"index"`
+	Delta openAIDelta `json:"delta"`
+	// llama-server extension: see openAIChoice.StoppingWord.
+	StoppingWord string  `json:"stopping_word,omitempty"`
+	FinishReason *string `json:"finish_reason"`
 }
 
 type openAIDelta struct {
-	Role    string `json:"role,omitempty"`
-	Content string `json:"content,omitempty"`
+	Role      string                `json:"role,omitempty"`
+	Content   string                `json:"content,omitempty"`
+	ToolCalls []openAIToolCallDelta `json:"tool_calls,omitempty"`
+}
+
+// openAIToolCallDelta is the per-chunk slice of a tool call. id / type /
+// function.name arrive on the first chunk; function.arguments accumulates
+// across subsequent chunks as a string of JSON fragments.
+type openAIToolCallDelta struct {
+	Index    int                          `json:"index"`
+	ID       string                       `json:"id,omitempty"`
+	Type     string                       `json:"type,omitempty"`
+	Function *openAIToolCallFunctionDelta `json:"function,omitempty"`
+}
+
+type openAIToolCallFunctionDelta struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
 }
 
 // --- Translation: request ---
@@ -230,11 +304,20 @@ var allowedImageMediaTypes = map[string]bool{
 }
 
 // rawJSONPresent reports whether a json.RawMessage is a meaningful value —
-// not absent and not the literal `null`. Without this, `"tool_choice": null`
-// would be incorrectly treated as present (4 bytes) and rejected.
+// not absent, not the literal `null`, and not an empty structure. Without
+// the empty-structure check, `"tool_choice": {}` or `"tools": []` from a
+// client that unconditionally attaches the field would be treated as a
+// request for tool use.
 func rawJSONPresent(raw json.RawMessage) bool {
 	trimmed := bytes.TrimSpace(raw)
-	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null"))
+	if len(trimmed) == 0 {
+		return false
+	}
+	switch string(trimmed) {
+	case "null", "[]", "{}":
+		return false
+	}
+	return true
 }
 
 func translateAnthropicRequest(body []byte) (openAIBody []byte, stream bool, err error) {
@@ -242,19 +325,8 @@ func translateAnthropicRequest(body []byte) (openAIBody []byte, stream bool, err
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, false, newBadRequest("Failed to parse request body as JSON")
 	}
-
-	if rawJSONPresent(req.Tools) || rawJSONPresent(req.ToolChoice) {
-		return nil, false, newBadRequest("tools/tool_choice are not yet supported in /v1/messages; use /v1/chat/completions directly")
-	}
-
-	// Anthropic requires max_tokens. Enforce it so a missing/zero value
-	// doesn't silently turn into llama-server's n_predict=-1 (runaway).
-	if req.MaxTokens <= 0 {
-		return nil, false, newBadRequest("max_tokens: Field required (must be > 0)")
-	}
-
-	if len(req.StopSequences) > maxStopSequences {
-		return nil, false, newBadRequest(fmt.Sprintf("stop_sequences: at most %d entries allowed", maxStopSequences))
+	if err := validateAnthropicRequest(&req); err != nil {
+		return nil, false, err
 	}
 
 	out := openAIChatRequest{
@@ -271,27 +343,18 @@ func translateAnthropicRequest(body []byte) (openAIBody []byte, stream bool, err
 	if req.Stream {
 		out.StreamOptions = &openAIStreamOpts{IncludeUsage: true}
 	}
-
-	if len(req.System) > 0 {
-		sysContent, err := flattenAnthropicSystem(req.System)
-		if err != nil {
-			return nil, false, err
-		}
-		if sysContent != "" {
-			raw, _ := json.Marshal(sysContent)
-			out.Messages = append(out.Messages, openAIMessage{
-				Role:    "system",
-				Content: raw,
-			})
-		}
+	if err := applyTools(&req, &out); err != nil {
+		return nil, false, err
 	}
-
+	if err := applySystem(&req, &out); err != nil {
+		return nil, false, err
+	}
 	for i, m := range req.Messages {
 		translated, err := translateAnthropicMessage(m)
 		if err != nil {
 			return nil, false, newBadRequest(fmt.Sprintf("messages[%d]: %s", i, err.Error()))
 		}
-		out.Messages = append(out.Messages, translated)
+		out.Messages = append(out.Messages, translated...)
 	}
 
 	b, err := json.Marshal(out)
@@ -299,6 +362,144 @@ func translateAnthropicRequest(body []byte) (openAIBody []byte, stream bool, err
 		return nil, false, fmt.Errorf("marshal translated request: %w", err)
 	}
 	return b, req.Stream, nil
+}
+
+// validateAnthropicRequest enforces the request invariants we can check
+// before translation: max_tokens is required, stop_sequences is capped,
+// and tool_choice without tools is a client mistake.
+func validateAnthropicRequest(req *anthropicMessagesRequest) error {
+	if req.MaxTokens <= 0 {
+		return newBadRequest("max_tokens: Field required (must be > 0)")
+	}
+	if len(req.StopSequences) > maxStopSequences {
+		return newBadRequest(fmt.Sprintf("stop_sequences: at most %d entries allowed", maxStopSequences))
+	}
+	if rawJSONPresent(req.ToolChoice) && len(req.Tools) == 0 {
+		return newBadRequest("tool_choice provided without tools")
+	}
+	return nil
+}
+
+// applyTools translates the request-level tools + tool_choice onto out.
+func applyTools(req *anthropicMessagesRequest, out *openAIChatRequest) error {
+	if len(req.Tools) > 0 {
+		translated, err := translateAnthropicTools(req.Tools)
+		if err != nil {
+			return err
+		}
+		out.Tools = translated
+	}
+	if rawJSONPresent(req.ToolChoice) {
+		tc, err := translateAnthropicToolChoice(req.ToolChoice)
+		if err != nil {
+			return err
+		}
+		out.ToolChoice = tc
+	}
+	return nil
+}
+
+// applySystem flattens the polymorphic system field onto out as a
+// role:"system" message when non-empty.
+func applySystem(req *anthropicMessagesRequest, out *openAIChatRequest) error {
+	if len(req.System) == 0 {
+		return nil
+	}
+	sysContent, err := flattenAnthropicSystem(req.System)
+	if err != nil {
+		return err
+	}
+	if sysContent == "" {
+		return nil
+	}
+	raw, _ := json.Marshal(sysContent)
+	out.Messages = append(out.Messages, openAIMessage{
+		Role:    "system",
+		Content: raw,
+	})
+	return nil
+}
+
+// translateAnthropicTools converts Anthropic's tool descriptors to the
+// OpenAI `tools` schema. The translation is mechanical: Anthropic's
+// {name, description, input_schema} maps 1:1 to OpenAI's
+// {type:"function", function:{name, description, parameters}}.
+func translateAnthropicTools(tools []anthropicTool) ([]openAITool, error) {
+	out := make([]openAITool, 0, len(tools))
+	for i, t := range tools {
+		if t.Name == "" {
+			return nil, newBadRequest(fmt.Sprintf("tools[%d]: name is required", i))
+		}
+		if len(t.InputSchema) == 0 {
+			return nil, newBadRequest(fmt.Sprintf("tools[%d]: input_schema is required", i))
+		}
+		out = append(out, openAITool{
+			Type: "function",
+			Function: openAIToolFunction{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  t.InputSchema,
+			},
+		})
+	}
+	return out, nil
+}
+
+// translateAnthropicToolChoice maps Anthropic's tool_choice shape to OpenAI's.
+//
+// Anthropic accepts:
+//
+//	"auto"                            // model decides (also: {"type":"auto"})
+//	{"type":"any"}                    // model must call a tool
+//	{"type":"tool","name":"foo"}      // model must call this specific tool
+//	{"type":"none"}                   // disallow tool use
+//
+// OpenAI accepts:
+//
+//	"auto" | "required" | "none"
+//	{"type":"function","function":{"name":"foo"}}
+func translateAnthropicToolChoice(raw json.RawMessage) (json.RawMessage, error) {
+	trimmed := bytes.TrimSpace(raw)
+
+	// String shorthand — only "auto" is documented for Anthropic. "required"
+	// / "none" are not in the Anthropic spec but pass through harmlessly to
+	// OpenAI backends that accept them.
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return nil, newBadRequest("tool_choice: invalid string value")
+		}
+		switch s {
+		case "auto", "required", "none":
+			return json.Marshal(s)
+		}
+		return nil, newBadRequest(fmt.Sprintf("tool_choice: unsupported string value %q", s))
+	}
+
+	var tc struct {
+		Type string `json:"type"`
+		Name string `json:"name,omitempty"`
+	}
+	if err := json.Unmarshal(trimmed, &tc); err != nil {
+		return nil, newBadRequest("tool_choice: expected object with `type` field")
+	}
+	switch tc.Type {
+	case "auto", "":
+		return json.Marshal("auto")
+	case "any":
+		return json.Marshal("required")
+	case "none":
+		return json.Marshal("none")
+	case "tool":
+		if tc.Name == "" {
+			return nil, newBadRequest(`tool_choice: {"type":"tool"} requires "name"`)
+		}
+		return json.Marshal(map[string]any{
+			"type":     "function",
+			"function": map[string]string{"name": tc.Name},
+		})
+	}
+	return nil, newBadRequest(fmt.Sprintf("tool_choice: unsupported type %q", tc.Type))
 }
 
 // flattenAnthropicSystem accepts either a JSON string or an array of
@@ -327,65 +528,192 @@ func flattenAnthropicSystem(raw json.RawMessage) (string, error) {
 	return strings.Join(parts, "\n\n"), nil
 }
 
-// translateAnthropicMessage converts a single Anthropic message (role + content)
-// into an OpenAI message. Content may be a string or an array of content blocks.
-func translateAnthropicMessage(m anthropicMessage) (openAIMessage, error) {
-	// Try string content first
+// translateAnthropicMessage converts a single Anthropic message into one or
+// more OpenAI messages. A single Anthropic user message carrying N
+// tool_result blocks fans out to N OpenAI role:"tool" messages (plus
+// optional user-text preamble); an assistant message with tool_use blocks
+// collapses into one OpenAI assistant message with tool_calls.
+func translateAnthropicMessage(m anthropicMessage) ([]openAIMessage, error) {
+	// String content is the simple case — just wrap it.
 	var s string
 	if err := json.Unmarshal(m.Content, &s); err == nil {
 		raw, _ := json.Marshal(s)
-		return openAIMessage{Role: m.Role, Content: raw}, nil
+		return []openAIMessage{{Role: m.Role, Content: raw}}, nil
 	}
 
-	// Array of content blocks
 	var blocks []anthropicContentBlock
 	if err := json.Unmarshal(m.Content, &blocks); err != nil {
-		return openAIMessage{}, fmt.Errorf("content: expected string or array of blocks")
+		return nil, fmt.Errorf("content: expected string or array of blocks")
 	}
 
-	// Initialize as empty slice so an empty content array marshals to `[]`
-	// rather than `null`. llama-server rejects null content on some message
-	// roles; `[]` is structurally valid.
+	if m.Role == "assistant" {
+		return translateAssistantBlocks(blocks)
+	}
+	return translateUserBlocks(blocks)
+}
+
+// translateAssistantBlocks handles an assistant turn. The allowed block
+// types are text and tool_use (plus thinking/redacted_thinking, which we
+// drop — they're advisory and backends that don't support them would
+// reject the message). Tool calls become openAIToolCalls on a single
+// assistant message.
+func translateAssistantBlocks(blocks []anthropicContentBlock) ([]openAIMessage, error) {
+	var textParts []string
+	var toolCalls []openAIToolCall
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			textParts = append(textParts, b.Text)
+		case "tool_use":
+			if b.ID == "" || b.Name == "" {
+				return nil, fmt.Errorf("tool_use: id and name are required")
+			}
+			args := "{}"
+			if len(b.Input) > 0 {
+				args = string(b.Input)
+			}
+			toolCalls = append(toolCalls, openAIToolCall{
+				ID:   b.ID,
+				Type: "function",
+				Function: openAIToolCallFunction{
+					Name:      b.Name,
+					Arguments: args,
+				},
+			})
+		case "thinking", "redacted_thinking":
+			// Drop — upstream reasoning markers that aren't part of the
+			// conversation the backend needs to see.
+		default:
+			return nil, fmt.Errorf("unsupported assistant content block type %q", b.Type)
+		}
+	}
+	msg := openAIMessage{Role: "assistant"}
+	if len(textParts) > 0 {
+		raw, _ := json.Marshal(strings.Join(textParts, ""))
+		msg.Content = raw
+	}
+	msg.ToolCalls = toolCalls
+	return []openAIMessage{msg}, nil
+}
+
+// translateUserBlocks handles a user turn. Tool results split out into
+// their own role:"tool" messages (OpenAI requires one tool message per
+// tool_call_id); text and image blocks remain on a single user message,
+// preserving ordering.
+func translateUserBlocks(blocks []anthropicContentBlock) ([]openAIMessage, error) {
+	var out []openAIMessage
 	parts := []openAIContentPart{}
+
+	flushUser := func() {
+		if len(parts) == 0 {
+			return
+		}
+		raw, _ := json.Marshal(parts)
+		out = append(out, openAIMessage{Role: "user", Content: raw})
+		parts = []openAIContentPart{}
+	}
+
 	for _, b := range blocks {
 		switch b.Type {
 		case "text":
 			parts = append(parts, openAIContentPart{Type: "text", Text: b.Text})
 		case "image":
-			if b.Source == nil {
-				return openAIMessage{}, fmt.Errorf("image: missing source")
+			p, err := translateImageBlock(b)
+			if err != nil {
+				return nil, err
 			}
-			var imageURL string
-			switch b.Source.Type {
-			case "base64":
-				if !allowedImageMediaTypes[b.Source.MediaType] {
-					return openAIMessage{}, fmt.Errorf("image: unsupported media_type %q", b.Source.MediaType)
-				}
-				imageURL = fmt.Sprintf("data:%s;base64,%s", b.Source.MediaType, b.Source.Data)
-			case "url":
-				if b.Source.URL == "" {
-					return openAIMessage{}, fmt.Errorf("image: url source missing url")
-				}
-				imageURL = b.Source.URL
-			default:
-				return openAIMessage{}, fmt.Errorf("image: unsupported source type %q", b.Source.Type)
+			parts = append(parts, p)
+		case "tool_result":
+			// Tool results must go on their own role:"tool" message. Flush
+			// any pending user content first so the conversation ordering
+			// is preserved.
+			flushUser()
+			toolMsg, err := translateToolResultBlock(b)
+			if err != nil {
+				return nil, err
 			}
-			parts = append(parts, openAIContentPart{
-				Type:     "image_url",
-				ImageURL: &openAIImageURL{URL: imageURL},
-			})
-		case "tool_use", "tool_result":
-			return openAIMessage{}, fmt.Errorf("%s content blocks are not yet supported", b.Type)
+			out = append(out, toolMsg)
 		default:
-			return openAIMessage{}, fmt.Errorf("unsupported content block type %q", b.Type)
+			return nil, fmt.Errorf("unsupported user content block type %q", b.Type)
 		}
 	}
+	flushUser()
+	return out, nil
+}
 
-	raw, err := json.Marshal(parts)
+// translateImageBlock converts an Anthropic image block to OpenAI's
+// image_url content part. URL sources are refused with a clear 400 because
+// llama-server and SwiftLM don't fetch remote URLs — forwarding would
+// produce an opaque backend error. Base64 sources are reformatted into a
+// data URL.
+func translateImageBlock(b anthropicContentBlock) (openAIContentPart, error) {
+	if b.Source == nil {
+		return openAIContentPart{}, fmt.Errorf("image: missing source")
+	}
+	switch b.Source.Type {
+	case "base64":
+		if !allowedImageMediaTypes[b.Source.MediaType] {
+			return openAIContentPart{}, fmt.Errorf("image: unsupported media_type %q", b.Source.MediaType)
+		}
+		return openAIContentPart{
+			Type: "image_url",
+			ImageURL: &openAIImageURL{
+				URL: fmt.Sprintf("data:%s;base64,%s", b.Source.MediaType, b.Source.Data),
+			},
+		}, nil
+	case "url":
+		return openAIContentPart{}, fmt.Errorf("image: url sources are not supported by the selected backend; re-send as base64")
+	default:
+		return openAIContentPart{}, fmt.Errorf("image: unsupported source type %q", b.Source.Type)
+	}
+}
+
+// translateToolResultBlock builds a role:"tool" OpenAI message from one
+// Anthropic tool_result block. The content is flattened to a string —
+// OpenAI's tool role does not carry structured blocks. Errors are prefixed
+// with "[error] " so the model can distinguish them from successful results.
+func translateToolResultBlock(b anthropicContentBlock) (openAIMessage, error) {
+	if b.ToolUseID == "" {
+		return openAIMessage{}, fmt.Errorf("tool_result: tool_use_id is required")
+	}
+	text, err := flattenToolResultContent(b.ToolContent)
 	if err != nil {
 		return openAIMessage{}, err
 	}
-	return openAIMessage{Role: m.Role, Content: raw}, nil
+	if b.ToolIsError {
+		text = "[error] " + text
+	}
+	raw, _ := json.Marshal(text)
+	return openAIMessage{
+		Role:       "tool",
+		ToolCallID: b.ToolUseID,
+		Content:    raw,
+	}, nil
+}
+
+// flattenToolResultContent accepts the polymorphic Anthropic tool_result
+// content: a bare string, an array of content blocks, or a single object.
+// Images inside tool_result are intentionally dropped — OpenAI's tool role
+// can't carry them, and the model sees the text explanation alone.
+func flattenToolResultContent(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 {
+		return "", nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, nil
+	}
+	var blocks []anthropicContentBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return "", fmt.Errorf("tool_result.content: expected string or array of blocks")
+	}
+	var parts []string
+	for _, b := range blocks {
+		if b.Type == "text" {
+			parts = append(parts, b.Text)
+		}
+	}
+	return strings.Join(parts, "\n"), nil
 }
 
 // --- Translation: non-streaming response ---
@@ -409,13 +737,42 @@ func translateOpenAIResponse(body []byte, messageID string) ([]byte, error) {
 		return nil, err
 	}
 
+	// Build content blocks: text first (if any), then tool_use blocks for
+	// each tool_call. Omit the text block when there's no text AND there
+	// are tool calls — a bare tool_use response shouldn't carry an empty
+	// assistant turn.
+	var content []anthropicResponseContent
+	if text != "" || len(choice.Message.ToolCalls) == 0 {
+		content = append(content, anthropicResponseContent{Type: "text", Text: text})
+	}
+	for _, tc := range choice.Message.ToolCalls {
+		input := json.RawMessage(tc.Function.Arguments)
+		if len(input) == 0 {
+			input = json.RawMessage(`{}`)
+		}
+		content = append(content, anthropicResponseContent{
+			Type:  "tool_use",
+			ID:    tc.ID,
+			Name:  tc.Function.Name,
+			Input: input,
+		})
+	}
+
+	stopReason := mapFinishReasonForResponse(choice)
+	var stopSequence *string
+	if stopReason == "stop_sequence" && choice.StoppingWord != "" {
+		sw := choice.StoppingWord
+		stopSequence = &sw
+	}
+
 	out := anthropicMessagesResponse{
-		ID:         messageID,
-		Type:       "message",
-		Role:       "assistant",
-		Model:      resp.Model,
-		StopReason: mapFinishReason(choice.FinishReason),
-		Content:    []anthropicResponseContent{{Type: "text", Text: text}},
+		ID:           messageID,
+		Type:         "message",
+		Role:         "assistant",
+		Model:        resp.Model,
+		StopReason:   stopReason,
+		StopSequence: stopSequence,
+		Content:      content,
 		Usage: anthropicUsage{
 			InputTokens:  resp.Usage.PromptTokens,
 			OutputTokens: resp.Usage.CompletionTokens,
@@ -423,6 +780,20 @@ func translateOpenAIResponse(body []byte, messageID string) ([]byte, error) {
 	}
 
 	return json.Marshal(out)
+}
+
+// mapFinishReasonForResponse extends the generic mapFinishReason so the
+// caller can opt into the "stop_sequence" Anthropic value when llama-server
+// reports which user-supplied stop string matched (via choice.StoppingWord).
+// Without this signal, every match degrades to the generic "end_turn".
+func mapFinishReasonForResponse(choice openAIChoice) string {
+	if choice.FinishReason == "stop" && choice.StoppingWord != "" {
+		return "stop_sequence"
+	}
+	if choice.FinishReason == "tool_calls" || choice.FinishReason == "function_call" {
+		return "tool_use"
+	}
+	return mapFinishReason(choice.FinishReason)
 }
 
 // extractOpenAIText pulls a plain text string out of an OpenAI message.Content
@@ -448,6 +819,43 @@ func extractOpenAIText(raw json.RawMessage) (string, error) {
 	return buf.String(), nil
 }
 
+// normalizeAnthropicErrorType constrains an upstream-supplied error type
+// string to Anthropic's enumerated set. Unknown values fall back to
+// api_error rather than propagating backend-specific strings ("model_error",
+// "BadRequestError", vendor prefixes) into SDK consumers that switch on type.
+func normalizeAnthropicErrorType(raw string) AnthropicErrorType {
+	switch AnthropicErrorType(raw) {
+	case AnthropicInvalidRequest, AnthropicAuthentication, AnthropicPermission,
+		AnthropicNotFound, AnthropicRequestTooLarge, AnthropicRateLimit,
+		AnthropicAPIError, AnthropicOverloaded:
+		return AnthropicErrorType(raw)
+	}
+	return AnthropicAPIError
+}
+
+// anthropicErrorTypeForStatus maps an HTTP status from the backend to the
+// Anthropic error type our error response carries. Keeps users' monitoring
+// consistent regardless of which backend failed.
+func anthropicErrorTypeForStatus(status int) AnthropicErrorType {
+	switch status {
+	case 400:
+		return AnthropicInvalidRequest
+	case 401:
+		return AnthropicAuthentication
+	case 403:
+		return AnthropicPermission
+	case 404:
+		return AnthropicNotFound
+	case 413:
+		return AnthropicRequestTooLarge
+	case 429:
+		return AnthropicRateLimit
+	case 503:
+		return AnthropicOverloaded
+	}
+	return AnthropicAPIError
+}
+
 // mapFinishReason maps OpenAI finish_reason to Anthropic stop_reason.
 // Empty / unknown values map to "end_turn" (Anthropic's default).
 func mapFinishReason(r string) string {
@@ -469,13 +877,32 @@ func mapFinishReason(r string) string {
 
 // streamState accumulates the transform as OpenAI SSE events are consumed
 // and exposes helpers for emitting the corresponding Anthropic events.
+//
+// Anthropic's streaming model puts every content piece (text and each
+// tool_use) on its own numbered content_block, with start/delta/stop
+// events. OpenAI's stream delivers text as `delta.content` and tool calls
+// as `delta.tool_calls[].function.arguments` string fragments across chunks.
+// We map each OpenAI tool_call.index to a freshly allocated Anthropic
+// content-block index; the text block (index 0) is allocated lazily on
+// the first text delta. openToolBlocks tracks which OpenAI tool indices
+// have already emitted content_block_start so we don't repeat it.
 type streamState struct {
 	w                io.Writer
 	flush            func()
 	messageID, model string
-	started          bool // emitted message_start + content_block_start
 	completionTokens int
 	stopReason       string
+	stopSequence     string // populated when llama-server reports a stop word match
+
+	started        bool // emitted message_start
+	textOpen       bool // text content block (Anthropic index = textIndex) started
+	textIndex      int  // Anthropic content_block index for the text block
+	nextBlockIndex int  // next Anthropic content_block index to allocate
+
+	// openAI tool_call.index → Anthropic content_block index
+	toolBlockIndex map[int]int
+	// Anthropic content_block index → whether content_block_stop still needed
+	openBlocks map[int]bool
 }
 
 func newStreamState(w io.Writer, messageID, model string) *streamState {
@@ -483,7 +910,14 @@ func newStreamState(w io.Writer, messageID, model string) *streamState {
 	if f, ok := w.(interface{ Flush() }); ok {
 		flush = f.Flush
 	}
-	return &streamState{w: w, flush: flush, messageID: messageID, model: model}
+	return &streamState{
+		w:              w,
+		flush:          flush,
+		messageID:      messageID,
+		model:          model,
+		toolBlockIndex: make(map[int]int),
+		openBlocks:     make(map[int]bool),
+	}
 }
 
 func (s *streamState) writeEvent(event string, data any) error {
@@ -498,12 +932,15 @@ func (s *streamState) writeEvent(event string, data any) error {
 	return nil
 }
 
-func (s *streamState) ensureStarted() error {
+// ensureMessageStarted emits the message_start frame once. Callers invoke
+// this before allocating any content block, and finalize invokes it so an
+// empty upstream still produces a well-formed Anthropic message.
+func (s *streamState) ensureMessageStarted() error {
 	if s.started {
 		return nil
 	}
 	s.started = true
-	err := s.writeEvent("message_start", map[string]any{
+	return s.writeEvent("message_start", map[string]any{
 		"type": "message_start",
 		"message": map[string]any{
 			"id":            s.messageID,
@@ -516,17 +953,60 @@ func (s *streamState) ensureStarted() error {
 			"usage":         map[string]int{"input_tokens": 0, "output_tokens": 0},
 		},
 	})
-	if err != nil {
+}
+
+// ensureTextBlock emits content_block_start for the text block on first use.
+// The text block always sits at index 0 (per Anthropic convention) unless
+// a tool block already claimed it — which can't happen here because we
+// allocate indices deterministically in the first ensure call.
+func (s *streamState) ensureTextBlock() error {
+	if s.textOpen {
+		return nil
+	}
+	if err := s.ensureMessageStarted(); err != nil {
 		return err
 	}
+	s.textIndex = s.nextBlockIndex
+	s.nextBlockIndex++
+	s.textOpen = true
+	s.openBlocks[s.textIndex] = true
 	// Anthropic's documented content_block_start carries a text block with
 	// an empty string. SDKs (notably the Python/TS accumulators) construct a
 	// TextBlock from this event and expect `text` to be present.
 	return s.writeEvent("content_block_start", map[string]any{
 		"type":          "content_block_start",
-		"index":         0,
+		"index":         s.textIndex,
 		"content_block": map[string]string{"type": "text", "text": ""},
 	})
+}
+
+// ensureToolBlock emits content_block_start for an OpenAI tool_call index
+// the first time we see it, returning the Anthropic content_block index.
+// Name is required by Anthropic; an OpenAI stream that omits it on the
+// first frame produces an empty-name tool_use block — non-ideal, but
+// better than dropping the tool call entirely.
+func (s *streamState) ensureToolBlock(openAIIdx int, toolID, toolName string) (int, error) {
+	if idx, ok := s.toolBlockIndex[openAIIdx]; ok {
+		return idx, nil
+	}
+	if err := s.ensureMessageStarted(); err != nil {
+		return 0, err
+	}
+	idx := s.nextBlockIndex
+	s.nextBlockIndex++
+	s.toolBlockIndex[openAIIdx] = idx
+	s.openBlocks[idx] = true
+	err := s.writeEvent("content_block_start", map[string]any{
+		"type":  "content_block_start",
+		"index": idx,
+		"content_block": map[string]any{
+			"type":  "tool_use",
+			"id":    toolID,
+			"name":  toolName,
+			"input": map[string]any{},
+		},
+	})
+	return idx, err
 }
 
 // errStreamAborted signals translateAnthropicStream that the upstream
@@ -553,17 +1033,7 @@ func (s *streamState) applyChunk(chunk *openAIStreamChunk) error {
 	// `event: error` and stop — further chunks would be semantically
 	// meaningless after an error.
 	if chunk.Error != nil {
-		errType := chunk.Error.Type
-		if errType == "" {
-			errType = string(AnthropicAPIError)
-		}
-		if err := s.writeEvent("error", map[string]any{
-			"type": "error",
-			"error": map[string]string{
-				"type":    errType,
-				"message": chunk.Error.Message,
-			},
-		}); err != nil {
+		if err := s.emitError(string(normalizeAnthropicErrorType(chunk.Error.Type)), chunk.Error.Message); err != nil {
 			return err
 		}
 		return errStreamAborted
@@ -575,40 +1045,108 @@ func (s *streamState) applyChunk(chunk *openAIStreamChunk) error {
 		s.completionTokens = chunk.Usage.CompletionTokens
 	}
 	for _, c := range chunk.Choices {
-		if c.Delta.Content != "" {
-			if err := s.ensureStarted(); err != nil {
-				return err
-			}
-			if err := s.writeEvent("content_block_delta", map[string]any{
-				"type":  "content_block_delta",
-				"index": 0,
-				"delta": map[string]string{"type": "text_delta", "text": c.Delta.Content},
-			}); err != nil {
-				return err
-			}
+		if err := s.applyTextDelta(c.Delta.Content); err != nil {
+			return err
+		}
+		if err := s.applyToolCallDeltas(c.Delta.ToolCalls); err != nil {
+			return err
 		}
 		if c.FinishReason != nil && *c.FinishReason != "" {
-			s.stopReason = mapFinishReason(*c.FinishReason)
+			s.stopReason = mapFinishReasonForStream(*c.FinishReason, c.StoppingWord)
+			if c.StoppingWord != "" {
+				s.stopSequence = c.StoppingWord
+			}
 		}
 	}
 	return nil
 }
 
-func (s *streamState) finalize() error {
-	// Ensure a valid message frame even if upstream produced nothing.
-	// After this, s.started is always true and the block needs its stop event.
-	if err := s.ensureStarted(); err != nil {
+func (s *streamState) applyTextDelta(text string) error {
+	if text == "" {
+		return nil
+	}
+	if err := s.ensureTextBlock(); err != nil {
 		return err
 	}
-	if err := s.writeEvent("content_block_stop", map[string]any{
-		"type":  "content_block_stop",
-		"index": 0,
-	}); err != nil {
+	return s.writeEvent("content_block_delta", map[string]any{
+		"type":  "content_block_delta",
+		"index": s.textIndex,
+		"delta": map[string]string{"type": "text_delta", "text": text},
+	})
+}
+
+func (s *streamState) applyToolCallDeltas(deltas []openAIToolCallDelta) error {
+	for _, d := range deltas {
+		name := ""
+		args := ""
+		if d.Function != nil {
+			name = d.Function.Name
+			args = d.Function.Arguments
+		}
+		idx, err := s.ensureToolBlock(d.Index, d.ID, name)
+		if err != nil {
+			return err
+		}
+		if args == "" {
+			continue
+		}
+		if err := s.writeEvent("content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"index": idx,
+			"delta": map[string]string{
+				"type":         "input_json_delta",
+				"partial_json": args,
+			},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// mapFinishReasonForStream extends mapFinishReason with llama-server's
+// stopping_word signal, same shape as the non-streaming path.
+func mapFinishReasonForStream(finish, stoppingWord string) string {
+	if finish == "stop" && stoppingWord != "" {
+		return "stop_sequence"
+	}
+	return mapFinishReason(finish)
+}
+
+func (s *streamState) finalize() error {
+	// Ensure a valid message frame even if upstream produced nothing.
+	if err := s.ensureMessageStarted(); err != nil {
 		return err
+	}
+	// If neither text nor tool blocks opened, Anthropic still needs at
+	// least one content block in the message — emit an empty text block so
+	// SDK accumulators don't receive a malformed empty message.
+	if len(s.openBlocks) == 0 {
+		if err := s.ensureTextBlock(); err != nil {
+			return err
+		}
+	}
+	// Stop every open block in allocation order (stable output; SDK
+	// accumulators walk by index).
+	for i := 0; i < s.nextBlockIndex; i++ {
+		if !s.openBlocks[i] {
+			continue
+		}
+		if err := s.writeEvent("content_block_stop", map[string]any{
+			"type":  "content_block_stop",
+			"index": i,
+		}); err != nil {
+			return err
+		}
+		delete(s.openBlocks, i)
 	}
 	stopReason := s.stopReason
 	if stopReason == "" {
 		stopReason = "end_turn"
+	}
+	var stopSequence any
+	if s.stopSequence != "" {
+		stopSequence = s.stopSequence
 	}
 	// Per Anthropic's spec, message_delta.usage is the cumulative running
 	// total and carries only output_tokens; input_tokens belongs in
@@ -618,7 +1156,7 @@ func (s *streamState) finalize() error {
 		"type": "message_delta",
 		"delta": map[string]any{
 			"stop_reason":   stopReason,
-			"stop_sequence": nil,
+			"stop_sequence": stopSequence,
 		},
 		"usage": map[string]int{
 			"output_tokens": s.completionTokens,
@@ -699,21 +1237,27 @@ func handleStreamLine(state *streamState, line []byte) (bool, error) {
 
 // countAnthropicTokens returns an approximate token count for an Anthropic
 // /v1/messages/count_tokens request body. Anthropic requires this endpoint
-// but llama-server and SwiftLM don't expose an OpenAI-equivalent, so we
-// approximate with a characters-per-token ratio. The approximation is
-// intentionally conservative (overcount slightly) so callers don't plan a
-// prompt that then overruns the context window at inference time.
+// but llama-server and SwiftLM don't expose an OpenAI-equivalent that works
+// without loading the model, so we approximate.
+//
+// The estimate is deliberately pessimistic:
+//   - ~2.5 chars/token covers the common adversarial cases (whitespace-
+//     heavy code, JSON, CJK), where real BPE tokenizers run well below the
+//     English-prose 3.5–4.0 ratio.
+//   - perMessageOverhead captures the chat-template framing tokens (role
+//     markers, separators, turn boundaries) that don't show up in content
+//     strings but are real context-window consumption.
+//   - Tool schemas contribute too — they're serialized to JSON and fed
+//     into the system prompt by most chat templates.
+//
+// This biases toward overcount. That's the correct direction: aider and
+// other planners drop/summarize history based on this number; an
+// undercount leads to mid-stream context-window overruns, which are
+// user-visible crashes.
 func countAnthropicTokens(body []byte) (int, error) {
 	var req anthropicMessagesRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return 0, newBadRequest("Failed to parse request body as JSON")
-	}
-
-	// Reject tool/tool_choice for the same reason /v1/messages does —
-	// and because tool schemas contribute meaningful token counts that
-	// our char-ratio approximation would silently undercount.
-	if rawJSONPresent(req.Tools) || rawJSONPresent(req.ToolChoice) {
-		return 0, newBadRequest("tools/tool_choice are not yet supported in /v1/messages/count_tokens")
 	}
 
 	var total int
@@ -724,33 +1268,67 @@ func countAnthropicTokens(body []byte) (int, error) {
 		}
 		total += approxTokens(sys)
 	}
+	for _, t := range req.Tools {
+		// Approximate a tool descriptor by its JSON footprint — name,
+		// description, and schema all get serialized into the chat template.
+		b, _ := json.Marshal(t)
+		total += approxTokens(string(b))
+	}
 	for _, m := range req.Messages {
-		var s string
-		if err := json.Unmarshal(m.Content, &s); err == nil {
-			total += approxTokens(s)
-			continue
-		}
-		var blocks []anthropicContentBlock
-		if err := json.Unmarshal(m.Content, &blocks); err != nil {
-			continue
-		}
-		for _, b := range blocks {
-			if b.Type == "text" {
-				total += approxTokens(b.Text)
-			}
-			// image tokens are non-trivial to estimate; omit for now
-		}
+		total += perMessageOverhead
+		total += approxMessageTokens(m)
 	}
 	return total, nil
 }
 
-// approxTokens estimates tokens for a plain text string. Empirically, English
-// text runs ~3.5 chars/token across modern BPE tokenizers; we use 3.5 and
-// round up so the estimate leans toward overcounting.
+// approxMessageTokens sums the token footprint of every block in one
+// message. Text and tool_use inputs count as JSON strings; tool_result
+// content flattens via the same path as translation. Image blocks
+// intentionally skip the estimator — per-image Anthropic token costs are
+// model-dependent and callers sending images should not rely on
+// count_tokens for budgeting.
+func approxMessageTokens(m anthropicMessage) int {
+	var s string
+	if err := json.Unmarshal(m.Content, &s); err == nil {
+		return approxTokens(s)
+	}
+	var blocks []anthropicContentBlock
+	if err := json.Unmarshal(m.Content, &blocks); err != nil {
+		return 0
+	}
+	var total int
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			total += approxTokens(b.Text)
+		case "tool_use":
+			total += approxTokens(b.Name) + approxTokens(string(b.Input))
+		case "tool_result":
+			if s, err := flattenToolResultContent(b.ToolContent); err == nil {
+				total += approxTokens(s)
+			}
+		}
+	}
+	return total
+}
+
+const (
+	// charsPerToken is the inverse of our chars/token ratio — 2.5 → 2.
+	// Kept as an integer so the rounding stays deterministic.
+	charsPerToken = 5
+	// perMessageOverhead is the per-turn token cost of the chat template
+	// framing (role markers, BOS/EOS, separators). Conservative; real
+	// overhead varies 4–8 tokens across common templates.
+	perMessageOverhead = 8
+)
+
+// approxTokens estimates tokens for a plain text string using ceil(len*2 / 5).
+// 2.5 chars/token leans pessimistic enough to cover non-English / code /
+// JSON inputs where modern BPE tokenizers compress poorly.
 func approxTokens(s string) int {
 	if s == "" {
 		return 0
 	}
-	// ceil(len*2 / 7) == ceil(len / 3.5)
-	return (len(s)*2 + 6) / 7
+	// ceil(len * 2 / 5)
+	return (len(s)*2 + charsPerToken - 1) / charsPerToken
 }

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -1,0 +1,617 @@
+package proxy
+
+// Translation between the Anthropic Messages API (/v1/messages) and the
+// OpenAI Chat Completions API (/v1/chat/completions). Anthropic translation
+// happens here so backends only need to speak OpenAI; this lets llama-server
+// and SwiftLM (which has no Anthropic endpoint) present a consistent surface.
+//
+// Scope for this pass:
+//   - Text content: full support (string or array of {type:"text", text:...}).
+//   - Image content: full support (base64 → OpenAI data URL).
+//   - Tool calling (request-level tools/tool_choice, plus tool_use and
+//     tool_result content blocks): rejected with a 400 because the two APIs
+//     disagree enough that a partial translation would silently misbehave.
+//     Will revisit when SwiftLM's tool-calling story firms up.
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// --- Anthropic request/response types ---
+
+type anthropicMessagesRequest struct {
+	Model         string             `json:"model"`
+	Messages      []anthropicMessage `json:"messages"`
+	System        json.RawMessage    `json:"system,omitempty"` // string or array of {type,text}
+	MaxTokens     int                `json:"max_tokens"`
+	Temperature   *float64           `json:"temperature,omitempty"`
+	TopP          *float64           `json:"top_p,omitempty"`
+	TopK          *int               `json:"top_k,omitempty"`
+	StopSequences []string           `json:"stop_sequences,omitempty"`
+	Stream        bool               `json:"stream,omitempty"`
+	Tools         json.RawMessage    `json:"tools,omitempty"`
+	ToolChoice    json.RawMessage    `json:"tool_choice,omitempty"`
+	Metadata      json.RawMessage    `json:"metadata,omitempty"` // ignored
+}
+
+type anthropicMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"` // string or array of content blocks
+}
+
+type anthropicContentBlock struct {
+	Type   string                `json:"type"`
+	Text   string                `json:"text,omitempty"`
+	Source *anthropicImageSource `json:"source,omitempty"`
+	// tool_use / tool_result fields intentionally not modeled — rejected at request-parse time.
+}
+
+type anthropicImageSource struct {
+	Type      string `json:"type"`       // "base64"
+	MediaType string `json:"media_type"` // e.g. "image/png"
+	Data      string `json:"data"`
+}
+
+type anthropicMessagesResponse struct {
+	ID           string                     `json:"id"`
+	Type         string                     `json:"type"` // always "message"
+	Role         string                     `json:"role"` // always "assistant"
+	Content      []anthropicResponseContent `json:"content"`
+	Model        string                     `json:"model"`
+	StopReason   string                     `json:"stop_reason,omitempty"`
+	StopSequence *string                    `json:"stop_sequence"`
+	Usage        anthropicUsage             `json:"usage"`
+}
+
+type anthropicResponseContent struct {
+	Type string `json:"type"` // "text"
+	Text string `json:"text"`
+}
+
+type anthropicUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// --- OpenAI types we produce / consume ---
+
+type openAIChatRequest struct {
+	Model         string            `json:"model"`
+	Messages      []openAIMessage   `json:"messages"`
+	MaxTokens     int               `json:"max_tokens,omitempty"`
+	Temperature   *float64          `json:"temperature,omitempty"`
+	TopP          *float64          `json:"top_p,omitempty"`
+	TopK          *int              `json:"top_k,omitempty"`
+	Stop          []string          `json:"stop,omitempty"`
+	Stream        bool              `json:"stream,omitempty"`
+	StreamOptions *openAIStreamOpts `json:"stream_options,omitempty"`
+}
+
+// openAIStreamOpts controls streaming extensions we need. include_usage
+// asks the backend to emit a final chunk with token counts so the
+// Anthropic message_delta event can carry real usage numbers.
+type openAIStreamOpts struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
+type openAIMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"` // string or multimodal array
+}
+
+type openAIContentPart struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text,omitempty"`
+	ImageURL *openAIImageURL `json:"image_url,omitempty"`
+}
+
+type openAIImageURL struct {
+	URL string `json:"url"`
+}
+
+type openAIChatResponse struct {
+	ID      string         `json:"id"`
+	Model   string         `json:"model"`
+	Choices []openAIChoice `json:"choices"`
+	Usage   openAIUsage    `json:"usage"`
+}
+
+type openAIChoice struct {
+	Index        int           `json:"index"`
+	Message      openAIMessage `json:"message"`
+	FinishReason string        `json:"finish_reason"`
+}
+
+type openAIUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// openAIStreamChunk is a single SSE event body from /v1/chat/completions
+type openAIStreamChunk struct {
+	ID      string               `json:"id"`
+	Model   string               `json:"model"`
+	Choices []openAIStreamChoice `json:"choices"`
+	Usage   *openAIUsage         `json:"usage,omitempty"`
+}
+
+type openAIStreamChoice struct {
+	Index        int         `json:"index"`
+	Delta        openAIDelta `json:"delta"`
+	FinishReason *string     `json:"finish_reason"`
+}
+
+type openAIDelta struct {
+	Role    string `json:"role,omitempty"`
+	Content string `json:"content,omitempty"`
+}
+
+// --- Translation: request ---
+
+// translateAnthropicRequest converts an Anthropic /v1/messages request to an
+// OpenAI /v1/chat/completions request. Returns the translated body, whether
+// the caller asked for streaming, and a translation error. Translation errors
+// carry an HTTP status so the handler can map them to Anthropic error types.
+type translateError struct {
+	status  int
+	errType AnthropicErrorType
+	msg     string
+}
+
+func (e *translateError) Error() string { return e.msg }
+
+func newBadRequest(msg string) *translateError {
+	return &translateError{status: 400, errType: AnthropicInvalidRequest, msg: msg}
+}
+
+// maxStopSequences mirrors Anthropic's documented cap (4) so a malicious or
+// buggy client can't push unbounded stop lists into the backend.
+const maxStopSequences = 4
+
+// allowedImageMediaTypes restricts the media_type clients can pass in image
+// blocks. Matches Anthropic's accepted set; defense-in-depth against the
+// client-supplied value being embedded into a data URL.
+var allowedImageMediaTypes = map[string]bool{
+	"image/jpeg": true,
+	"image/png":  true,
+	"image/gif":  true,
+	"image/webp": true,
+}
+
+// rawJSONPresent reports whether a json.RawMessage is a meaningful value —
+// not absent and not the literal `null`. Without this, `"tool_choice": null`
+// would be incorrectly treated as present (4 bytes) and rejected.
+func rawJSONPresent(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null"))
+}
+
+func translateAnthropicRequest(body []byte) (openAIBody []byte, stream bool, err error) {
+	var req anthropicMessagesRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, false, newBadRequest("Failed to parse request body as JSON")
+	}
+
+	if rawJSONPresent(req.Tools) || rawJSONPresent(req.ToolChoice) {
+		return nil, false, newBadRequest("tools/tool_choice are not yet supported in /v1/messages; use /v1/chat/completions directly")
+	}
+
+	// Anthropic requires max_tokens. Enforce it so a missing/zero value
+	// doesn't silently turn into llama-server's n_predict=-1 (runaway).
+	if req.MaxTokens <= 0 {
+		return nil, false, newBadRequest("max_tokens: Field required (must be > 0)")
+	}
+
+	if len(req.StopSequences) > maxStopSequences {
+		return nil, false, newBadRequest(fmt.Sprintf("stop_sequences: at most %d entries allowed", maxStopSequences))
+	}
+
+	out := openAIChatRequest{
+		Model:       req.Model,
+		MaxTokens:   req.MaxTokens,
+		Temperature: req.Temperature,
+		TopP:        req.TopP,
+		TopK:        req.TopK,
+		Stop:        req.StopSequences,
+		Stream:      req.Stream,
+	}
+	// Ask the backend for usage in the final streaming chunk so we can fill
+	// in Anthropic's message_delta.usage instead of always reporting zeros.
+	if req.Stream {
+		out.StreamOptions = &openAIStreamOpts{IncludeUsage: true}
+	}
+
+	if len(req.System) > 0 {
+		sysContent, err := flattenAnthropicSystem(req.System)
+		if err != nil {
+			return nil, false, err
+		}
+		if sysContent != "" {
+			raw, _ := json.Marshal(sysContent)
+			out.Messages = append(out.Messages, openAIMessage{
+				Role:    "system",
+				Content: raw,
+			})
+		}
+	}
+
+	for i, m := range req.Messages {
+		translated, err := translateAnthropicMessage(m)
+		if err != nil {
+			return nil, false, newBadRequest(fmt.Sprintf("messages[%d]: %s", i, err.Error()))
+		}
+		out.Messages = append(out.Messages, translated)
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		return nil, false, fmt.Errorf("marshal translated request: %w", err)
+	}
+	return b, req.Stream, nil
+}
+
+// flattenAnthropicSystem accepts either a JSON string or an array of
+// {type:"text", text:"..."} blocks and returns the concatenated text.
+func flattenAnthropicSystem(raw json.RawMessage) (string, error) {
+	// Try string first
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, nil
+	}
+	// Fall back to array of content blocks
+	var blocks []anthropicContentBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return "", newBadRequest("system: expected string or array of text blocks")
+	}
+	var parts []string
+	for _, b := range blocks {
+		if b.Type != "text" {
+			return "", newBadRequest("system: only text blocks are supported")
+		}
+		parts = append(parts, b.Text)
+	}
+	// Anthropic concatenates system text blocks with a blank-line separator
+	// when forming the model's system prompt. Matching that avoids subtle
+	// prompt-wording drift for prompt-sensitive models.
+	return strings.Join(parts, "\n\n"), nil
+}
+
+// translateAnthropicMessage converts a single Anthropic message (role + content)
+// into an OpenAI message. Content may be a string or an array of content blocks.
+func translateAnthropicMessage(m anthropicMessage) (openAIMessage, error) {
+	// Try string content first
+	var s string
+	if err := json.Unmarshal(m.Content, &s); err == nil {
+		raw, _ := json.Marshal(s)
+		return openAIMessage{Role: m.Role, Content: raw}, nil
+	}
+
+	// Array of content blocks
+	var blocks []anthropicContentBlock
+	if err := json.Unmarshal(m.Content, &blocks); err != nil {
+		return openAIMessage{}, fmt.Errorf("content: expected string or array of blocks")
+	}
+
+	// Initialize as empty slice so an empty content array marshals to `[]`
+	// rather than `null`. llama-server rejects null content on some message
+	// roles; `[]` is structurally valid.
+	parts := []openAIContentPart{}
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			parts = append(parts, openAIContentPart{Type: "text", Text: b.Text})
+		case "image":
+			if b.Source == nil || b.Source.Type != "base64" {
+				return openAIMessage{}, fmt.Errorf("image: only base64 sources are supported")
+			}
+			if !allowedImageMediaTypes[b.Source.MediaType] {
+				return openAIMessage{}, fmt.Errorf("image: unsupported media_type %q", b.Source.MediaType)
+			}
+			url := fmt.Sprintf("data:%s;base64,%s", b.Source.MediaType, b.Source.Data)
+			parts = append(parts, openAIContentPart{
+				Type:     "image_url",
+				ImageURL: &openAIImageURL{URL: url},
+			})
+		case "tool_use", "tool_result":
+			return openAIMessage{}, fmt.Errorf("%s content blocks are not yet supported", b.Type)
+		default:
+			return openAIMessage{}, fmt.Errorf("unsupported content block type %q", b.Type)
+		}
+	}
+
+	raw, err := json.Marshal(parts)
+	if err != nil {
+		return openAIMessage{}, err
+	}
+	return openAIMessage{Role: m.Role, Content: raw}, nil
+}
+
+// --- Translation: non-streaming response ---
+
+// translateOpenAIResponse converts an OpenAI chat completion response into the
+// Anthropic /v1/messages response format. messageID is the id to stamp on the
+// Anthropic response (typically generated upstream).
+func translateOpenAIResponse(body []byte, messageID string) ([]byte, error) {
+	var resp openAIChatResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decode openai response: %w", err)
+	}
+
+	if len(resp.Choices) == 0 {
+		return nil, fmt.Errorf("openai response has no choices")
+	}
+	choice := resp.Choices[0]
+
+	text, err := extractOpenAIText(choice.Message.Content)
+	if err != nil {
+		return nil, err
+	}
+
+	out := anthropicMessagesResponse{
+		ID:         messageID,
+		Type:       "message",
+		Role:       "assistant",
+		Model:      resp.Model,
+		StopReason: mapFinishReason(choice.FinishReason),
+		Content:    []anthropicResponseContent{{Type: "text", Text: text}},
+		Usage: anthropicUsage{
+			InputTokens:  resp.Usage.PromptTokens,
+			OutputTokens: resp.Usage.CompletionTokens,
+		},
+	}
+
+	return json.Marshal(out)
+}
+
+// extractOpenAIText pulls a plain text string out of an OpenAI message.Content
+// value, which can be either a JSON string or an array of content parts.
+func extractOpenAIText(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 {
+		return "", nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, nil
+	}
+	var parts []openAIContentPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return "", fmt.Errorf("unexpected content shape in assistant response")
+	}
+	var buf strings.Builder
+	for _, p := range parts {
+		if p.Type == "text" {
+			buf.WriteString(p.Text)
+		}
+	}
+	return buf.String(), nil
+}
+
+// mapFinishReason maps OpenAI finish_reason to Anthropic stop_reason.
+// Empty / unknown values map to "end_turn" (Anthropic's default).
+func mapFinishReason(r string) string {
+	switch r {
+	case "stop":
+		return "end_turn"
+	case "length":
+		return "max_tokens"
+	case "tool_calls", "function_call":
+		return "tool_use"
+	case "":
+		return ""
+	default:
+		return "end_turn"
+	}
+}
+
+// --- Translation: streaming ---
+
+// streamState accumulates the transform as OpenAI SSE events are consumed
+// and exposes helpers for emitting the corresponding Anthropic events.
+type streamState struct {
+	w                io.Writer
+	flush            func()
+	messageID, model string
+	started          bool // emitted message_start + content_block_start
+	promptTokens     int
+	completionTokens int
+	stopReason       string
+}
+
+func newStreamState(w io.Writer, messageID, model string) *streamState {
+	flush := func() {}
+	if f, ok := w.(interface{ Flush() }); ok {
+		flush = f.Flush
+	}
+	return &streamState{w: w, flush: flush, messageID: messageID, model: model}
+}
+
+func (s *streamState) writeEvent(event string, data any) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(s.w, "event: %s\ndata: %s\n\n", event, b); err != nil {
+		return err
+	}
+	s.flush()
+	return nil
+}
+
+func (s *streamState) ensureStarted() error {
+	if s.started {
+		return nil
+	}
+	s.started = true
+	err := s.writeEvent("message_start", map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id":            s.messageID,
+			"type":          "message",
+			"role":          "assistant",
+			"content":       []any{},
+			"model":         s.model,
+			"stop_reason":   nil,
+			"stop_sequence": nil,
+			"usage":         map[string]int{"input_tokens": 0, "output_tokens": 0},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return s.writeEvent("content_block_start", map[string]any{
+		"type":          "content_block_start",
+		"index":         0,
+		"content_block": map[string]string{"type": "text"},
+	})
+}
+
+func (s *streamState) applyChunk(chunk *openAIStreamChunk) error {
+	if chunk.Usage != nil {
+		s.promptTokens = chunk.Usage.PromptTokens
+		s.completionTokens = chunk.Usage.CompletionTokens
+	}
+	for _, c := range chunk.Choices {
+		if c.Delta.Content != "" {
+			if err := s.ensureStarted(); err != nil {
+				return err
+			}
+			if err := s.writeEvent("content_block_delta", map[string]any{
+				"type":  "content_block_delta",
+				"index": 0,
+				"delta": map[string]string{"type": "text_delta", "text": c.Delta.Content},
+			}); err != nil {
+				return err
+			}
+		}
+		if c.FinishReason != nil && *c.FinishReason != "" {
+			s.stopReason = mapFinishReason(*c.FinishReason)
+		}
+	}
+	return nil
+}
+
+func (s *streamState) finalize() error {
+	// Ensure a valid message frame even if upstream produced nothing.
+	// After this, s.started is always true and the block needs its stop event.
+	if err := s.ensureStarted(); err != nil {
+		return err
+	}
+	if err := s.writeEvent("content_block_stop", map[string]any{
+		"type":  "content_block_stop",
+		"index": 0,
+	}); err != nil {
+		return err
+	}
+	stopReason := s.stopReason
+	if stopReason == "" {
+		stopReason = "end_turn"
+	}
+	if err := s.writeEvent("message_delta", map[string]any{
+		"type": "message_delta",
+		"delta": map[string]any{
+			"stop_reason":   stopReason,
+			"stop_sequence": nil,
+		},
+		"usage": map[string]int{
+			"input_tokens":  s.promptTokens,
+			"output_tokens": s.completionTokens,
+		},
+	}); err != nil {
+		return err
+	}
+	return s.writeEvent("message_stop", map[string]string{"type": "message_stop"})
+}
+
+// translateAnthropicStream reads OpenAI /v1/chat/completions SSE events from
+// upstream and emits an equivalent Anthropic /v1/messages SSE stream to w.
+// messageID is stamped into the emitted events; model is echoed back.
+// The writer must be an http.ResponseWriter configured for streaming; the
+// caller is responsible for flushing response headers first.
+func translateAnthropicStream(w io.Writer, upstream io.Reader, messageID, model string) error {
+	state := newStreamState(w, messageID, model)
+
+	scanner := bufio.NewScanner(upstream)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		var chunk openAIStreamChunk
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			// Skip malformed chunks rather than aborting the whole stream.
+			continue
+		}
+		if err := state.applyChunk(&chunk); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return state.finalize()
+}
+
+// --- Token counting ---
+
+// countAnthropicTokens returns an approximate token count for an Anthropic
+// /v1/messages/count_tokens request body. Anthropic requires this endpoint
+// but llama-server and SwiftLM don't expose an OpenAI-equivalent, so we
+// approximate with a characters-per-token ratio. The approximation is
+// intentionally conservative (overcount slightly) so callers don't plan a
+// prompt that then overruns the context window at inference time.
+func countAnthropicTokens(body []byte) (int, error) {
+	var req anthropicMessagesRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return 0, newBadRequest("Failed to parse request body as JSON")
+	}
+
+	var total int
+	if len(req.System) > 0 {
+		sys, err := flattenAnthropicSystem(req.System)
+		if err != nil {
+			return 0, err
+		}
+		total += approxTokens(sys)
+	}
+	for _, m := range req.Messages {
+		var s string
+		if err := json.Unmarshal(m.Content, &s); err == nil {
+			total += approxTokens(s)
+			continue
+		}
+		var blocks []anthropicContentBlock
+		if err := json.Unmarshal(m.Content, &blocks); err != nil {
+			continue
+		}
+		for _, b := range blocks {
+			if b.Type == "text" {
+				total += approxTokens(b.Text)
+			}
+			// image tokens are non-trivial to estimate; omit for now
+		}
+	}
+	return total, nil
+}
+
+// approxTokens estimates tokens for a plain text string. Empirically, English
+// text runs ~3.5 chars/token across modern BPE tokenizers; we use 3.5 and
+// round up so the estimate leans toward overcounting.
+func approxTokens(s string) int {
+	if s == "" {
+		return 0
+	}
+	// ceil(len*2 / 7) == ceil(len / 3.5)
+	return (len(s)*2 + 6) / 7
+}

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -534,6 +534,20 @@ func (s *streamState) ensureStarted() error {
 // been emitted; the stream loop should stop cleanly.
 var errStreamAborted = fmt.Errorf("stream aborted by upstream error")
 
+// emitError writes a synthetic Anthropic `event: error` frame. Used for
+// conditions the upstream didn't report as a structured error but that we
+// still want the SDK to see — e.g. a mid-stream I/O failure on the
+// upstream connection.
+func (s *streamState) emitError(errType, message string) error {
+	return s.writeEvent("error", map[string]any{
+		"type": "error",
+		"error": map[string]string{
+			"type":    errType,
+			"message": message,
+		},
+	})
+}
+
 func (s *streamState) applyChunk(chunk *openAIStreamChunk) error {
 	// Upstream signaled an error mid-stream. Translate to Anthropic's
 	// `event: error` and stop — further chunks would be semantically
@@ -620,40 +634,65 @@ func (s *streamState) finalize() error {
 // messageID is stamped into the emitted events; model is echoed back.
 // The writer must be an http.ResponseWriter configured for streaming; the
 // caller is responsible for flushing response headers first.
+//
+// Uses bufio.Reader.ReadBytes instead of bufio.Scanner because Scanner has
+// a hard token-length cap (defaults to 64 KiB; even raising it to 1 MiB is
+// fragile). A single `data:` line from a reasoning model or a tool-call
+// backend can exceed any static limit; silently dropping the rest of the
+// stream is the worst outcome. Each line is read as an independent
+// allocation, bounded only by Go's memory, and any I/O error that happens
+// mid-stream gets surfaced as a synthetic Anthropic error event instead of
+// a silent truncation.
 func translateAnthropicStream(w io.Writer, upstream io.Reader, messageID, model string) error {
 	state := newStreamState(w, messageID, model)
+	reader := bufio.NewReader(upstream)
 
-	scanner := bufio.NewScanner(upstream)
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		if !strings.HasPrefix(line, "data:") {
-			continue
-		}
-		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
-		if payload == "" || payload == "[DONE]" {
-			continue
-		}
-		var chunk openAIStreamChunk
-		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
-			// Skip malformed chunks rather than aborting the whole stream.
-			continue
-		}
-		if err := state.applyChunk(&chunk); err != nil {
-			if errors.Is(err, errStreamAborted) {
-				// Error event already emitted; don't tack on trailing
-				// message_delta/message_stop frames that would confuse
-				// the client about the final state.
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			if stop, handleErr := handleStreamLine(state, line); handleErr != nil {
+				return handleErr
+			} else if stop {
 				return nil
 			}
+		}
+		if err == io.EOF {
+			return state.finalize()
+		}
+		if err != nil {
+			// Mid-stream I/O error: emit an error frame so SDK consumers see
+			// an explicit failure instead of a stream that just stops.
+			_ = state.emitError("api_error", fmt.Sprintf("upstream stream error: %v", err))
 			return err
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return err
+}
+
+// handleStreamLine processes one SSE line. Returns (stop=true, nil) when
+// an upstream error event already emitted an Anthropic error frame and the
+// caller should return cleanly without tacking on trailing message_delta /
+// message_stop frames.
+func handleStreamLine(state *streamState, line []byte) (bool, error) {
+	trimmed := bytes.TrimRight(line, "\r\n")
+	if !bytes.HasPrefix(trimmed, []byte("data:")) {
+		return false, nil
 	}
-	return state.finalize()
+	payload := bytes.TrimSpace(bytes.TrimPrefix(trimmed, []byte("data:")))
+	if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
+		return false, nil
+	}
+	var chunk openAIStreamChunk
+	if err := json.Unmarshal(payload, &chunk); err != nil {
+		// Skip malformed chunks rather than aborting the whole stream.
+		return false, nil
+	}
+	if err := state.applyChunk(&chunk); err != nil {
+		if errors.Is(err, errStreamAborted) {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
 }
 
 // --- Token counting ---

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -7,26 +7,39 @@ package proxy
 //
 // Scope for this pass:
 //   - Text content: full support (string or array of {type:"text", text:...}).
-//   - Image content: full support (base64 → OpenAI data URL; accepted media
-//     types restricted to Anthropic's documented set).
+//   - Image content: base64 (media_type restricted to Anthropic's accepted set)
+//     and url sources both supported.
 //   - Tool calling (request-level tools/tool_choice, plus tool_use and
 //     tool_result content blocks): rejected with a 400 because the two APIs
 //     disagree enough that a partial translation would silently misbehave.
-//     Will revisit when SwiftLM's tool-calling story firms up.
-//   - Non-text content blocks (document, thinking, redacted_thinking, etc.)
-//     rejected with a 400.
+//     Will revisit when SwiftLM's tool-calling story firms up. Reference
+//     implementation: llama.cpp's tools/server/server-common.cpp
+//     convert_anthropic_to_oai() shows the full mapping (tool_use →
+//     tool_calls, tool_result → role:tool, tool_choice {auto|any|tool} →
+//     {auto|required|{name:...}}).
+//   - Extended-thinking blocks (thinking, redacted_thinking) and document
+//     blocks: rejected with a 400. llama.cpp forwards thinking as
+//     reasoning_content on the OpenAI side and emits signature_delta on
+//     the Anthropic side — worth adopting once SwiftLM's thinking story is
+//     clear.
 //
 // Known limitations relative to Anthropic's public spec (by design for now):
 //   - message_start.usage.input_tokens is always 0 in streamed responses.
 //     OpenAI with stream_options.include_usage only reports prompt_tokens in
 //     the final chunk; backfilling message_start would require buffering the
-//     entire stream and break TTFT. Documented, tested.
+//     entire stream and break TTFT. llama.cpp cheats by pre-tokenizing on
+//     the same process — we can't, without a separate tokenize round-trip.
 //   - stop_reason is never "stop_sequence" because OpenAI does not report
 //     which stop string matched. We map finish_reason="stop" to "end_turn".
 //   - OpenAI finish_reason="content_filter" maps to "end_turn" — Anthropic
 //     has no direct analog in the stop_reason enum.
 //   - Periodic ping events are not emitted; intermediaries that idle-close
 //     SSE connections may drop very long streams.
+//   - cache_creation_input_tokens / cache_read_input_tokens are not emitted.
+//     Requires backend-side prompt-cache tracking we don't currently have.
+//   - count_tokens is a char-ratio approximation, not a real tokenize call.
+//     llama.cpp runs the actual tokenizer in-process; our proxy would need
+//     a backend round-trip (or to load a tokenizer) for parity.
 //   - The anthropic-version request header is not enforced (local proxy).
 //   - Forward-compat: unknown top-level fields (service_tier, container,
 //     thinking, output_config, etc.) and cache_control hints on supported
@@ -72,9 +85,10 @@ type anthropicContentBlock struct {
 }
 
 type anthropicImageSource struct {
-	Type      string `json:"type"`       // "base64"
-	MediaType string `json:"media_type"` // e.g. "image/png"
-	Data      string `json:"data"`
+	Type      string `json:"type"`                 // "base64" | "url"
+	MediaType string `json:"media_type,omitempty"` // for base64 (e.g. "image/png")
+	Data      string `json:"data,omitempty"`       // for base64
+	URL       string `json:"url,omitempty"`        // for url
 }
 
 type anthropicMessagesResponse struct {
@@ -338,16 +352,27 @@ func translateAnthropicMessage(m anthropicMessage) (openAIMessage, error) {
 		case "text":
 			parts = append(parts, openAIContentPart{Type: "text", Text: b.Text})
 		case "image":
-			if b.Source == nil || b.Source.Type != "base64" {
-				return openAIMessage{}, fmt.Errorf("image: only base64 sources are supported")
+			if b.Source == nil {
+				return openAIMessage{}, fmt.Errorf("image: missing source")
 			}
-			if !allowedImageMediaTypes[b.Source.MediaType] {
-				return openAIMessage{}, fmt.Errorf("image: unsupported media_type %q", b.Source.MediaType)
+			var imageURL string
+			switch b.Source.Type {
+			case "base64":
+				if !allowedImageMediaTypes[b.Source.MediaType] {
+					return openAIMessage{}, fmt.Errorf("image: unsupported media_type %q", b.Source.MediaType)
+				}
+				imageURL = fmt.Sprintf("data:%s;base64,%s", b.Source.MediaType, b.Source.Data)
+			case "url":
+				if b.Source.URL == "" {
+					return openAIMessage{}, fmt.Errorf("image: url source missing url")
+				}
+				imageURL = b.Source.URL
+			default:
+				return openAIMessage{}, fmt.Errorf("image: unsupported source type %q", b.Source.Type)
 			}
-			url := fmt.Sprintf("data:%s;base64,%s", b.Source.MediaType, b.Source.Data)
 			parts = append(parts, openAIContentPart{
 				Type:     "image_url",
-				ImageURL: &openAIImageURL{URL: url},
+				ImageURL: &openAIImageURL{URL: imageURL},
 			})
 		case "tool_use", "tool_result":
 			return openAIMessage{}, fmt.Errorf("%s content blocks are not yet supported", b.Type)

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -20,9 +20,18 @@ package proxy
 //   - Streaming: tool_call deltas accumulate per OpenAI tool index into their
 //     own Anthropic content_block index; function.arguments fragments become
 //     input_json_delta partial_json events that SDK accumulators reassemble.
-//   - Extended-thinking blocks (thinking, redacted_thinking): dropped rather
-//     than rejected. They're advisory; backends that don't understand them
-//     would reject the message. Document blocks remain rejected.
+//   - Reasoning / extended-thinking: output-side passthrough. Backend
+//     reasoning_content (llama-server --reasoning-format deepseek; SwiftLM
+//     --thinking) translates to Anthropic thinking content blocks in both
+//     streaming (thinking_delta events) and non-streaming paths. Request-
+//     level `thinking: {type:"enabled", budget_tokens:N}` forwards as
+//     top-level `thinking_budget_tokens` (honored by llama-server, ignored
+//     by SwiftLM). Input-side thinking blocks in prior assistant messages
+//     are concatenated into `reasoning_content` on the OpenAI message —
+//     matches llama.cpp's own /v1/messages translator so reasoning-aware
+//     chat templates render prior chain-of-thought for multi-turn extended-
+//     thinking conversations. `redacted_thinking` is drop-only (no plaintext
+//     to replay; we never emit it either). Document blocks remain rejected.
 //   - Error translation: upstream error types map to Anthropic's enum via
 //     normalizeAnthropicErrorType; upstream HTTP status codes map via
 //     anthropicErrorTypeForStatus. SDK consumers never see backend-specific
@@ -73,6 +82,7 @@ type anthropicMessagesRequest struct {
 	Stream        bool               `json:"stream,omitempty"`
 	Tools         []anthropicTool    `json:"tools,omitempty"`
 	ToolChoice    json.RawMessage    `json:"tool_choice,omitempty"` // object shape varies; parsed separately
+	Thinking      json.RawMessage    `json:"thinking,omitempty"`    // {type:"enabled"|"disabled", budget_tokens:N}
 	Metadata      json.RawMessage    `json:"metadata,omitempty"`    // ignored
 }
 
@@ -105,6 +115,11 @@ type anthropicContentBlock struct {
 	ToolUseID   string          `json:"tool_use_id,omitempty"`
 	ToolContent json.RawMessage `json:"content,omitempty"`
 	ToolIsError bool            `json:"is_error,omitempty"`
+
+	// thinking (assistant-authored; appears in prior-turn history). The
+	// `signature` field on the same block is intentionally unmodeled —
+	// signatures are opaque Anthropic-server state with no local meaning.
+	Thinking string `json:"thinking,omitempty"`
 }
 
 type anthropicImageSource struct {
@@ -134,6 +149,13 @@ type anthropicResponseContent struct {
 	ID    string          `json:"id,omitempty"`
 	Name  string          `json:"name,omitempty"`
 	Input json.RawMessage `json:"input,omitempty"`
+
+	// thinking blocks. Signature is emitted as an empty string on local-model
+	// output (no verifiable-thinking state to stamp) to match the shape
+	// llama.cpp's native /v1/messages endpoint produces. Pointer so text/
+	// tool_use blocks leave it absent rather than emitting an empty field.
+	Thinking  string  `json:"thinking,omitempty"`
+	Signature *string `json:"signature,omitempty"`
 }
 
 type anthropicUsage struct {
@@ -144,17 +166,18 @@ type anthropicUsage struct {
 // --- OpenAI types we produce / consume ---
 
 type openAIChatRequest struct {
-	Model         string            `json:"model"`
-	Messages      []openAIMessage   `json:"messages"`
-	MaxTokens     int               `json:"max_tokens,omitempty"`
-	Temperature   *float64          `json:"temperature,omitempty"`
-	TopP          *float64          `json:"top_p,omitempty"`
-	TopK          *int              `json:"top_k,omitempty"`
-	Stop          []string          `json:"stop,omitempty"`
-	Stream        bool              `json:"stream,omitempty"`
-	StreamOptions *openAIStreamOpts `json:"stream_options,omitempty"`
-	Tools         []openAITool      `json:"tools,omitempty"`
-	ToolChoice    json.RawMessage   `json:"tool_choice,omitempty"`
+	Model                string            `json:"model"`
+	Messages             []openAIMessage   `json:"messages"`
+	MaxTokens            int               `json:"max_tokens,omitempty"`
+	Temperature          *float64          `json:"temperature,omitempty"`
+	TopP                 *float64          `json:"top_p,omitempty"`
+	TopK                 *int              `json:"top_k,omitempty"`
+	Stop                 []string          `json:"stop,omitempty"`
+	Stream               bool              `json:"stream,omitempty"`
+	StreamOptions        *openAIStreamOpts `json:"stream_options,omitempty"`
+	Tools                []openAITool      `json:"tools,omitempty"`
+	ToolChoice           json.RawMessage   `json:"tool_choice,omitempty"`
+	ThinkingBudgetTokens *int              `json:"thinking_budget_tokens,omitempty"`
 }
 
 type openAITool struct {
@@ -180,6 +203,11 @@ type openAIMessage struct {
 	Content    json.RawMessage  `json:"content,omitempty"` // string or multimodal array; may be absent for assistant tool_calls
 	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string           `json:"tool_call_id,omitempty"` // set when Role == "tool"
+	// ReasoningContent is the DeepSeek-convention field both llama-server
+	// (--reasoning-format deepseek, default) and SwiftLM (--thinking) emit
+	// on non-streaming assistant responses. Output-only: we don't forward
+	// it back as input because neither backend accepts it there.
+	ReasoningContent string `json:"reasoning_content,omitempty"`
 }
 
 type openAIToolCall struct {
@@ -258,6 +286,10 @@ type openAIDelta struct {
 	Role      string                `json:"role,omitempty"`
 	Content   string                `json:"content,omitempty"`
 	ToolCalls []openAIToolCallDelta `json:"tool_calls,omitempty"`
+	// ReasoningContent carries the reasoning (a.k.a. thinking) delta the
+	// backend extracted from <think> tags. Streaming-side counterpart to
+	// openAIMessage.ReasoningContent; translated to Anthropic thinking_delta.
+	ReasoningContent string `json:"reasoning_content,omitempty"`
 }
 
 // openAIToolCallDelta is the per-chunk slice of a tool call. id / type /
@@ -352,6 +384,9 @@ func translateAnthropicRequest(body []byte) (openAIBody []byte, stream bool, err
 	}
 	if err := applySystem(&req, &out); err != nil {
 		return nil, false, err
+	}
+	if budget, ok := parseAnthropicThinking(req.Thinking); ok {
+		out.ThinkingBudgetTokens = &budget
 	}
 	for i, m := range req.Messages {
 		translated, err := translateAnthropicMessage(m)
@@ -506,6 +541,33 @@ func translateAnthropicToolChoice(raw json.RawMessage) (json.RawMessage, error) 
 	return nil, newBadRequest(fmt.Sprintf("tool_choice: unsupported type %q", tc.Type))
 }
 
+// parseAnthropicThinking extracts the budget from Anthropic's request-level
+// thinking control: `{"type":"enabled", "budget_tokens": N}`. Returns ok=true
+// only when type=="enabled" and a budget is given.
+//
+// Mirrors llama.cpp's own /v1/messages handling: `thinking.budget_tokens` is
+// forwarded as top-level `thinking_budget_tokens` on the chat-completions
+// payload. llama-server honors it via the reasoning sampler; SwiftLM
+// tolerates unknown fields. Malformed / disabled / absent → ok=false (silent
+// forward-compat, consistent with how other unknown top-level fields are
+// tolerated by this proxy).
+func parseAnthropicThinking(raw json.RawMessage) (int, bool) {
+	if !rawJSONPresent(raw) {
+		return 0, false
+	}
+	var t struct {
+		Type         string `json:"type"`
+		BudgetTokens *int   `json:"budget_tokens,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &t); err != nil {
+		return 0, false
+	}
+	if t.Type != "enabled" || t.BudgetTokens == nil {
+		return 0, false
+	}
+	return *t.BudgetTokens, true
+}
+
 // flattenAnthropicSystem accepts either a JSON string or an array of
 // {type:"text", text:"..."} blocks and returns the concatenated text.
 func flattenAnthropicSystem(raw json.RawMessage) (string, error) {
@@ -563,6 +625,7 @@ func translateAnthropicMessage(m anthropicMessage) ([]openAIMessage, error) {
 // assistant message.
 func translateAssistantBlocks(blocks []anthropicContentBlock) ([]openAIMessage, error) {
 	var textParts []string
+	var reasoningParts []string
 	var toolCalls []openAIToolCall
 	for _, b := range blocks {
 		switch b.Type {
@@ -584,9 +647,19 @@ func translateAssistantBlocks(blocks []anthropicContentBlock) ([]openAIMessage, 
 					Arguments: args,
 				},
 			})
-		case "thinking", "redacted_thinking":
-			// Drop — upstream reasoning markers that aren't part of the
-			// conversation the backend needs to see.
+		case "thinking":
+			// Concatenate prior-turn thinking text into reasoning_content on
+			// the assistant message. Matches llama.cpp's native /v1/messages
+			// → chat-completions translation (server-common.cpp:1577). The
+			// chat template renders it via the reasoning slot (Qwen3,
+			// DeepSeek-R1, GLM-4.5) so the model sees its own prior chain of
+			// thought on multi-turn extended-thinking conversations. SwiftLM
+			// ignores unknown message fields, so this is safe there too.
+			reasoningParts = append(reasoningParts, b.Thinking)
+		case "redacted_thinking":
+			// Drop entirely — encrypted Anthropic-server-only state with no
+			// plaintext we can replay into a local model. Output is never
+			// produced either; drop-only by design.
 		default:
 			return nil, fmt.Errorf("unsupported assistant content block type %q", b.Type)
 		}
@@ -595,6 +668,9 @@ func translateAssistantBlocks(blocks []anthropicContentBlock) ([]openAIMessage, 
 	if len(textParts) > 0 {
 		raw, _ := json.Marshal(strings.Join(textParts, ""))
 		msg.Content = raw
+	}
+	if len(reasoningParts) > 0 {
+		msg.ReasoningContent = strings.Join(reasoningParts, "")
 	}
 	msg.ToolCalls = toolCalls
 	return []openAIMessage{msg}, nil
@@ -741,12 +817,26 @@ func translateOpenAIResponse(body []byte, messageID string) ([]byte, error) {
 		return nil, err
 	}
 
-	// Build content blocks: text first (if any), then tool_use blocks for
-	// each tool_call. Omit the text block when there's no text AND there
-	// are tool calls — a bare tool_use response shouldn't carry an empty
-	// assistant turn.
+	// Build content blocks: thinking first (if any), then text (if any),
+	// then tool_use blocks. Thinking-before-text mirrors llama.cpp's native
+	// /v1/messages output shape. Omit the text block when there's no text
+	// AND there are tool calls — a bare tool_use response shouldn't carry
+	// an empty assistant turn.
 	var content []anthropicResponseContent
-	if text != "" || len(choice.Message.ToolCalls) == 0 {
+	reasoning := choice.Message.ReasoningContent
+	if reasoning != "" {
+		empty := ""
+		content = append(content, anthropicResponseContent{
+			Type:      "thinking",
+			Thinking:  reasoning,
+			Signature: &empty,
+		})
+	}
+	// Emit a text block when there's actual text, OR when nothing else
+	// (thinking, tools) will carry the response — so an Anthropic message
+	// always has ≥1 content block. This matches llama.cpp's behavior of
+	// skipping empty text when thinking or tool_use fills the turn.
+	if text != "" || (reasoning == "" && len(choice.Message.ToolCalls) == 0) {
 		content = append(content, anthropicResponseContent{Type: "text", Text: text})
 	}
 	for _, tc := range choice.Message.ToolCalls {
@@ -905,6 +995,8 @@ type streamState struct {
 	started        bool // emitted message_start
 	textOpen       bool // text content block (Anthropic index = textIndex) started
 	textIndex      int  // Anthropic content_block index for the text block
+	thinkingOpen   bool // thinking content block started
+	thinkingIndex  int  // Anthropic content_block index for the thinking block
 	nextBlockIndex int  // next Anthropic content_block index to allocate
 
 	// openAI tool_call.index → Anthropic content_block index
@@ -987,6 +1079,37 @@ func (s *streamState) ensureTextBlock() error {
 		"type":          "content_block_start",
 		"index":         s.textIndex,
 		"content_block": map[string]string{"type": "text", "text": ""},
+	})
+}
+
+// ensureThinkingBlock emits content_block_start for a thinking block on
+// first use. Shape mirrors llama.cpp's native /v1/messages streaming output:
+// `{type:"thinking", thinking:""}` — signature is omitted here (non-streaming-
+// only in the reference), then followed by thinking_delta frames. Allocated
+// lazily so models that don't emit reasoning_content never produce a
+// thinking block.
+func (s *streamState) ensureThinkingBlock() error {
+	if s.thinkingOpen {
+		return nil
+	}
+	if err := s.ensureMessageStarted(); err != nil {
+		return err
+	}
+	s.thinkingIndex = s.nextBlockIndex
+	s.nextBlockIndex++
+	s.thinkingOpen = true
+	s.openBlocks[s.thinkingIndex] = true
+	// Signature is intentionally absent on the streaming start event — it's
+	// a non-streaming-only field in llama.cpp's reference output (see
+	// tools/server/server-task.cpp:to_json_anthropic_stream). SDK stream
+	// accumulators don't consume it here; emitting it would be a deviation.
+	return s.writeEvent("content_block_start", map[string]any{
+		"type":  "content_block_start",
+		"index": s.thinkingIndex,
+		"content_block": map[string]string{
+			"type":     "thinking",
+			"thinking": "",
+		},
 	})
 }
 
@@ -1099,6 +1222,13 @@ func (s *streamState) applyChunk(chunk *openAIStreamChunk) error {
 		s.completionTokens = chunk.Usage.CompletionTokens
 	}
 	for _, c := range chunk.Choices {
+		// Reasoning first: llama-server and SwiftLM emit reasoning_content
+		// before content, so this ordering also keeps the allocated
+		// content_block indices stable (thinking=0, text=1 on a typical
+		// reasoning turn) to match the non-streaming response shape.
+		if err := s.applyReasoningDelta(c.Delta.ReasoningContent); err != nil {
+			return err
+		}
 		if err := s.applyTextDelta(c.Delta.Content); err != nil {
 			return err
 		}
@@ -1113,6 +1243,23 @@ func (s *streamState) applyChunk(chunk *openAIStreamChunk) error {
 		}
 	}
 	return nil
+}
+
+// applyReasoningDelta emits a thinking_delta Anthropic event for each chunk
+// of backend reasoning_content. Shape mirrors llama.cpp's native
+// /v1/messages streaming: `{type:"thinking_delta", thinking: <text>}`.
+func (s *streamState) applyReasoningDelta(text string) error {
+	if text == "" {
+		return nil
+	}
+	if err := s.ensureThinkingBlock(); err != nil {
+		return err
+	}
+	return s.writeEvent("content_block_delta", map[string]any{
+		"type":  "content_block_delta",
+		"index": s.thinkingIndex,
+		"delta": map[string]string{"type": "thinking_delta", "thinking": text},
+	})
 }
 
 func (s *streamState) applyTextDelta(text string) error {

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -33,8 +33,10 @@ package proxy
 //     OpenAI with stream_options.include_usage only reports prompt_tokens in
 //     the final chunk; backfilling message_start would require buffering the
 //     entire stream and break TTFT.
-//   - Periodic ping events are not emitted; intermediaries that idle-close
-//     SSE connections may drop very long streams.
+//   - Periodic `event: ping` frames are emitted every streamPingInterval
+//     (default 15s) while a stream is open, so middleware (nginx defaults
+//     to a 60s idle-kill; corporate TLS terminators vary) doesn't drop
+//     slow-token generation mid-response.
 //   - cache_creation_input_tokens / cache_read_input_tokens are not emitted.
 //     Requires backend-side prompt-cache tracking we don't currently have.
 //   - count_tokens is a char-ratio approximation, not a real tokenize call.
@@ -53,6 +55,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
+	"time"
 )
 
 // --- Anthropic request/response types ---
@@ -887,6 +891,10 @@ func mapFinishReason(r string) string {
 // the first text delta. openToolBlocks tracks which OpenAI tool indices
 // have already emitted content_block_start so we don't repeat it.
 type streamState struct {
+	// writeMu serializes every SSE write because a parallel ping goroutine
+	// may interleave with the main chunk-processing loop. Nothing else on
+	// streamState is shared across goroutines.
+	writeMu          sync.Mutex
 	w                io.Writer
 	flush            func()
 	messageID, model string
@@ -925,6 +933,8 @@ func (s *streamState) writeEvent(event string, data any) error {
 	if err != nil {
 		return err
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
 	if _, err := fmt.Fprintf(s.w, "event: %s\ndata: %s\n\n", event, b); err != nil {
 		return err
 	}
@@ -1013,6 +1023,50 @@ func (s *streamState) ensureToolBlock(openAIIdx int, toolID, toolName string) (i
 // reported an error mid-stream and an Anthropic error event has already
 // been emitted; the stream loop should stop cleanly.
 var errStreamAborted = fmt.Errorf("stream aborted by upstream error")
+
+// startPings runs a goroutine that emits an `event: ping` frame every
+// `interval` until the returned stop function is called. Pings are
+// content-free — their only purpose is to keep idle-sensitive
+// intermediaries from dropping the connection. writeEvent serializes with
+// the main loop via writeMu so frames never interleave mid-JSON.
+//
+// startPings only fires the ticker after message_start has been written;
+// emitting a ping before any other frame would be out-of-sequence per
+// Anthropic's stream grammar. Returns a no-op stop when interval<=0 so
+// tests can disable pings without a special path.
+func (s *streamState) startPings(interval time.Duration) func() {
+	if interval <= 0 {
+		return func() {}
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				s.writeMu.Lock()
+				started := s.started
+				s.writeMu.Unlock()
+				if !started {
+					continue
+				}
+				// Ignore write errors: a broken connection is caught by
+				// the main loop's next write too; emitting a best-effort
+				// ping keeps the design simple.
+				_ = s.writeEvent("ping", map[string]string{"type": "ping"})
+			}
+		}
+	}()
+	return func() {
+		close(stop)
+		<-done
+	}
+}
 
 // emitError writes a synthetic Anthropic `event: error` frame. Used for
 // conditions the upstream didn't report as a structured error but that we
@@ -1181,8 +1235,21 @@ func (s *streamState) finalize() error {
 // allocation, bounded only by Go's memory, and any I/O error that happens
 // mid-stream gets surfaced as a synthetic Anthropic error event instead of
 // a silent truncation.
+// streamPingInterval is how often we emit an Anthropic `event: ping` while
+// waiting on a slow model. Many L7 proxies (nginx default 60s, corporate
+// SSL terminators) kill idle SSE connections — without pings, a 70B model
+// generating at a few tok/s can produce back-to-back chunks separated by
+// enough idle time to trip the timeout. 15s is well below every common
+// threshold we've seen.
+// streamPingInterval is how often we emit an Anthropic `event: ping`
+// while waiting on a slow model. var rather than const so tests can
+// override it without sleeping for 15 seconds.
+var streamPingInterval = 15 * time.Second
+
 func translateAnthropicStream(w io.Writer, upstream io.Reader, messageID, model string) error {
 	state := newStreamState(w, messageID, model)
+	stopPings := state.startPings(streamPingInterval)
+	defer stopPings()
 	reader := bufio.NewReader(upstream)
 
 	for {

--- a/internal/proxy/anthropic_test.go
+++ b/internal/proxy/anthropic_test.go
@@ -1222,38 +1222,63 @@ func TestTranslateAnthropicRequest_DocumentBlockRejected(t *testing.T) {
 	}
 }
 
-// Extended-thinking and redacted_thinking blocks are advisory; we drop
-// them from the translated request rather than reject, so an assistant
-// turn that carries them (from an earlier round with a reasoning-enabled
-// model) still gets through to backends that don't understand them.
-func TestTranslateAnthropicRequest_ThinkingBlockDropped(t *testing.T) {
-	for _, blockType := range []string{"thinking", "redacted_thinking"} {
-		t.Run(blockType, func(t *testing.T) {
-			body := []byte(`{
-				"model": "m",
-				"max_tokens": 5,
-				"messages": [{
-					"role": "assistant",
-					"content": [
-						{"type": "` + blockType + `", "thinking": "secret"},
-						{"type": "text", "text": "final answer"}
-					]
-				}]
-			}`)
-			out, _, err := translateAnthropicRequest(body)
-			if err != nil {
-				t.Fatalf("thinking block should be dropped, got err: %v", err)
-			}
-			// The thinking text must not leak into the backend request;
-			// only the surrounding text block remains.
-			if bytes.Contains(out, []byte("secret")) {
-				t.Errorf("thinking content leaked into translated request: %s", out)
-			}
-			if !bytes.Contains(out, []byte("final answer")) {
-				t.Errorf("surrounding text dropped: %s", out)
-			}
-		})
-	}
+// Prior-turn thinking blocks are concatenated into reasoning_content on the
+// upstream assistant message — matches llama.cpp's /v1/messages translator,
+// which feeds this through the chat template's reasoning slot so reasoning-
+// aware models see their own prior chain of thought. redacted_thinking is
+// encrypted Anthropic-server state with no plaintext to replay, so it's
+// dropped; its payload must never leak into reasoning_content.
+func TestTranslateAnthropicRequest_ThinkingBlockHandling(t *testing.T) {
+	t.Run("thinking forwarded to reasoning_content", func(t *testing.T) {
+		body := []byte(`{
+			"model": "m",
+			"max_tokens": 5,
+			"messages": [{
+				"role": "assistant",
+				"content": [
+					{"type": "thinking", "thinking": "secret"},
+					{"type": "text", "text": "final answer"}
+				]
+			}]
+		}`)
+		out, _, err := translateAnthropicRequest(body)
+		if err != nil {
+			t.Fatalf("translate: %v", err)
+		}
+		if !bytes.Contains(out, []byte(`"reasoning_content":"secret"`)) {
+			t.Errorf("thinking must forward as reasoning_content: %s", out)
+		}
+		if !bytes.Contains(out, []byte("final answer")) {
+			t.Errorf("surrounding text dropped: %s", out)
+		}
+	})
+
+	t.Run("redacted_thinking dropped", func(t *testing.T) {
+		body := []byte(`{
+			"model": "m",
+			"max_tokens": 5,
+			"messages": [{
+				"role": "assistant",
+				"content": [
+					{"type": "redacted_thinking", "data": "ENCRYPTED"},
+					{"type": "text", "text": "final answer"}
+				]
+			}]
+		}`)
+		out, _, err := translateAnthropicRequest(body)
+		if err != nil {
+			t.Fatalf("translate: %v", err)
+		}
+		if bytes.Contains(out, []byte("ENCRYPTED")) {
+			t.Errorf("redacted_thinking payload must not leak: %s", out)
+		}
+		if bytes.Contains(out, []byte("reasoning_content")) {
+			t.Errorf("redacted_thinking must not produce reasoning_content: %s", out)
+		}
+		if !bytes.Contains(out, []byte("final answer")) {
+			t.Errorf("surrounding text dropped: %s", out)
+		}
+	})
 }
 
 // Anthropic supports `source.type: "url"` for images, but llama-server and
@@ -1556,5 +1581,359 @@ func TestTranslateOpenAIResponse_StopSequenceNullPresent(t *testing.T) {
 	// be present, not omitted. A struct decode would silently hide omission.
 	if !strings.Contains(string(out), `"stop_sequence":null`) {
 		t.Errorf(`response should include "stop_sequence":null key; got %s`, string(out))
+	}
+}
+
+// --- Reasoning / thinking passthrough ---
+
+// Streaming reasoning_content must surface as an Anthropic thinking content
+// block with thinking_delta events. Shape mirrors llama.cpp's native
+// /v1/messages output so clients (Claude Code, aider) that already handle
+// extended-thinking from Anthropic's API render it without special casing.
+func TestTranslateAnthropicStream_ThinkingBlock(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"c","model":"m","choices":[{"index":0,"delta":{"reasoning_content":"Let me "}}]}`,
+		`data: {"id":"c","model":"m","choices":[{"index":0,"delta":{"reasoning_content":"think..."}}]}`,
+		`data: {"id":"c","model":"m","choices":[{"index":0,"delta":{"content":"Answer"}}]}`,
+		`data: {"id":"c","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(upstream), "msg_1", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	events := decodeSSE(t, buf.String())
+
+	// Find the first two content_block_start events and confirm thinking
+	// comes before text.
+	var starts []sseEvent
+	for _, e := range events {
+		if e.name == "content_block_start" {
+			starts = append(starts, e)
+		}
+	}
+	if len(starts) < 2 {
+		t.Fatalf("want >=2 content_block_start events, got %d\n%s", len(starts), buf.String())
+	}
+	if !strings.Contains(starts[0].data, `"type":"thinking"`) {
+		t.Errorf("first content_block_start should be thinking, got: %s", starts[0].data)
+	}
+	if !strings.Contains(starts[0].data, `"index":0`) {
+		t.Errorf("thinking block should be at index 0, got: %s", starts[0].data)
+	}
+	// signature is a non-streaming-only field; llama.cpp's streaming
+	// content_block_start omits it, so we match that shape.
+	if strings.Contains(starts[0].data, `"signature"`) {
+		t.Errorf("streaming content_block_start for thinking must not include signature, got: %s", starts[0].data)
+	}
+	if !strings.Contains(starts[1].data, `"type":"text"`) || !strings.Contains(starts[1].data, `"index":1`) {
+		t.Errorf("second content_block_start should be text at index 1, got: %s", starts[1].data)
+	}
+
+	// thinking_delta frames must carry the reasoning fragments in order.
+	wantThinkingFrags := []string{`"thinking":"Let me "`, `"thinking":"think..."`}
+	var thinkingIdx int
+	for _, e := range events {
+		if e.name != "content_block_delta" {
+			continue
+		}
+		if !strings.Contains(e.data, `"type":"thinking_delta"`) {
+			continue
+		}
+		if thinkingIdx >= len(wantThinkingFrags) {
+			t.Fatalf("unexpected extra thinking_delta: %s", e.data)
+		}
+		if !strings.Contains(e.data, wantThinkingFrags[thinkingIdx]) {
+			t.Errorf("thinking_delta[%d]: want %s in %s", thinkingIdx, wantThinkingFrags[thinkingIdx], e.data)
+		}
+		thinkingIdx++
+	}
+	if thinkingIdx != len(wantThinkingFrags) {
+		t.Errorf("got %d thinking_delta events, want %d", thinkingIdx, len(wantThinkingFrags))
+	}
+
+	// Both blocks must be stopped, in allocation order.
+	var stops []string
+	for _, e := range events {
+		if e.name == "content_block_stop" {
+			stops = append(stops, e.data)
+		}
+	}
+	if len(stops) != 2 {
+		t.Fatalf("want 2 content_block_stop, got %d: %v", len(stops), stops)
+	}
+	if !strings.Contains(stops[0], `"index":0`) || !strings.Contains(stops[1], `"index":1`) {
+		t.Errorf("content_block_stop order wrong: %v", stops)
+	}
+}
+
+// Reasoning-only stream (model reasons but emits no final content) must
+// still finalize cleanly with a stopped thinking block.
+func TestTranslateAnthropicStream_ThinkingOnly(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"index":0,"delta":{"reasoning_content":"thinking"}}]}`,
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(upstream), "msg_x", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, `"type":"thinking"`) {
+		t.Errorf("expected thinking block in output:\n%s", got)
+	}
+	if !strings.Contains(got, `"type":"thinking_delta"`) {
+		t.Errorf("expected thinking_delta in output:\n%s", got)
+	}
+	if !strings.Contains(got, "event: content_block_stop") {
+		t.Errorf("expected content_block_stop:\n%s", got)
+	}
+	if !strings.Contains(got, "event: message_stop") {
+		t.Errorf("expected message_stop:\n%s", got)
+	}
+}
+
+// Non-streaming: reasoning_content on the response message must surface as a
+// thinking content block prepended before text. Matches llama.cpp's native
+// /v1/messages block ordering.
+func TestTranslateOpenAIResponse_ThinkingBlock(t *testing.T) {
+	openAI := `{
+		"model": "m",
+		"choices": [{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"content": "The answer is 42.",
+				"reasoning_content": "Let me compute this step by step."
+			},
+			"finish_reason": "stop"
+		}],
+		"usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+	}`
+	out, err := translateOpenAIResponse([]byte(openAI), "msg_abc")
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var got anthropicMessagesResponse
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Content) != 2 {
+		t.Fatalf("want 2 content blocks (thinking, text), got %d: %+v", len(got.Content), got.Content)
+	}
+	if got.Content[0].Type != "thinking" {
+		t.Errorf("content[0].type = %q, want thinking", got.Content[0].Type)
+	}
+	if got.Content[0].Thinking != "Let me compute this step by step." {
+		t.Errorf("content[0].thinking = %q", got.Content[0].Thinking)
+	}
+	if got.Content[0].Signature == nil || *got.Content[0].Signature != "" {
+		t.Errorf("content[0].signature should be empty string (not nil/absent), got %v", got.Content[0].Signature)
+	}
+	if got.Content[1].Type != "text" || got.Content[1].Text != "The answer is 42." {
+		t.Errorf("content[1] = %+v, want text block", got.Content[1])
+	}
+
+	// Signature must serialize on the wire with an explicit empty string
+	// (matches llama.cpp's /v1/messages output). omitempty on the pointer
+	// would drop it if left nil.
+	if !strings.Contains(string(out), `"signature":""`) {
+		t.Errorf("raw output missing `\"signature\":\"\"`:\n%s", string(out))
+	}
+}
+
+// Response-level thinking only (rare but valid): reasoning_content set,
+// content empty, no tool calls. Matches llama.cpp's native /v1/messages
+// behavior — the empty text block is suppressed when thinking fills the turn.
+func TestTranslateOpenAIResponse_ThinkingWithoutText(t *testing.T) {
+	openAI := `{
+		"model": "m",
+		"choices": [{
+			"index": 0,
+			"message": {"role": "assistant", "content": "", "reasoning_content": "pondered"},
+			"finish_reason": "stop"
+		}],
+		"usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+	}`
+	out, err := translateOpenAIResponse([]byte(openAI), "msg_x")
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var got anthropicMessagesResponse
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Matches llama.cpp: an empty text block is not appended when thinking
+	// already fills the turn. Only the thinking block should be present.
+	if len(got.Content) != 1 || got.Content[0].Type != "thinking" {
+		t.Errorf("want [thinking] only, got: %+v", got.Content)
+	}
+}
+
+// Request-side: Anthropic thinking.budget_tokens must forward to the
+// OpenAI payload as top-level thinking_budget_tokens. Mirrors llama.cpp's
+// own /v1/messages handling so requests reach llama-server's reasoning
+// sampler with the same knob value.
+func TestTranslateAnthropicRequest_ThinkingBudget(t *testing.T) {
+	tests := []struct {
+		name      string
+		thinking  string
+		wantField bool
+		wantValue int
+	}{
+		{
+			name:      "enabled with budget",
+			thinking:  `{"type":"enabled","budget_tokens":4096}`,
+			wantField: true,
+			wantValue: 4096,
+		},
+		{
+			name:      "disabled",
+			thinking:  `{"type":"disabled"}`,
+			wantField: false,
+		},
+		{
+			name:      "enabled without budget",
+			thinking:  `{"type":"enabled"}`,
+			wantField: false,
+		},
+		{
+			name:      "absent",
+			thinking:  "",
+			wantField: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var thinkingField string
+			if tc.thinking != "" {
+				thinkingField = `,"thinking":` + tc.thinking
+			}
+			body := `{"model":"m","max_tokens":16,"messages":[{"role":"user","content":"hi"}]` + thinkingField + `}`
+			out, _, err := translateAnthropicRequest([]byte(body))
+			if err != nil {
+				t.Fatalf("translate: %v", err)
+			}
+			var got openAIChatRequest
+			if err := json.Unmarshal(out, &got); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if tc.wantField {
+				if got.ThinkingBudgetTokens == nil {
+					t.Fatalf("thinking_budget_tokens absent; want %d", tc.wantValue)
+				}
+				if *got.ThinkingBudgetTokens != tc.wantValue {
+					t.Errorf("thinking_budget_tokens = %d, want %d", *got.ThinkingBudgetTokens, tc.wantValue)
+				}
+			} else {
+				if got.ThinkingBudgetTokens != nil {
+					t.Errorf("thinking_budget_tokens should be absent, got %d", *got.ThinkingBudgetTokens)
+				}
+				if strings.Contains(string(out), "thinking_budget_tokens") {
+					t.Errorf("wire output should not contain thinking_budget_tokens: %s", string(out))
+				}
+			}
+		})
+	}
+}
+
+// Assistant-history thinking blocks must be concatenated into
+// reasoning_content on the upstream assistant message — matches llama.cpp's
+// /v1/messages translator so reasoning-aware chat templates (Qwen3,
+// DeepSeek-R1, GLM-4.5) render prior chain-of-thought on multi-turn
+// extended-thinking conversations. redacted_thinking is drop-only.
+func TestTranslateAnthropicRequest_AssistantThinkingForwarded(t *testing.T) {
+	body := `{
+		"model": "m",
+		"max_tokens": 16,
+		"messages": [
+			{"role": "user", "content": "2+2?"},
+			{"role": "assistant", "content": [
+				{"type": "thinking", "thinking": "pondering...", "signature": "sig"},
+				{"type": "redacted_thinking", "data": "ENCRYPTED"},
+				{"type": "text", "text": "4"}
+			]},
+			{"role": "user", "content": "thanks"}
+		]
+	}`
+	out, _, err := translateAnthropicRequest([]byte(body))
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var got openAIChatRequest
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var assistant *openAIMessage
+	for i := range got.Messages {
+		if got.Messages[i].Role == "assistant" {
+			assistant = &got.Messages[i]
+			break
+		}
+	}
+	if assistant == nil {
+		t.Fatalf("no assistant message in translated request:\n%s", string(out))
+	}
+	if assistant.ReasoningContent != "pondering..." {
+		t.Errorf("reasoning_content = %q, want %q", assistant.ReasoningContent, "pondering...")
+	}
+	if !strings.Contains(string(assistant.Content), `4`) {
+		t.Errorf("assistant text must survive: %s", string(assistant.Content))
+	}
+	// redacted_thinking carries no plaintext; its placeholder payload must
+	// not leak into reasoning_content.
+	if strings.Contains(assistant.ReasoningContent, "ENCRYPTED") {
+		t.Errorf("redacted_thinking data must not leak into reasoning_content: %q", assistant.ReasoningContent)
+	}
+}
+
+// Non-streaming: reasoning_content + tool_calls with no text content must
+// produce [thinking, tool_use] with no empty text block — matches
+// llama.cpp's behavior of skipping empty text when the turn is already
+// filled by other block types.
+func TestTranslateOpenAIResponse_ThinkingPlusToolCall(t *testing.T) {
+	openAI := `{
+		"model": "m",
+		"choices": [{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"content": "",
+				"reasoning_content": "Should call fetch.",
+				"tool_calls": [{
+					"id": "call_1",
+					"type": "function",
+					"function": {"name": "fetch", "arguments": "{\"url\":\"https://x\"}"}
+				}]
+			},
+			"finish_reason": "tool_calls"
+		}],
+		"usage": {"prompt_tokens": 10, "completion_tokens": 8, "total_tokens": 18}
+	}`
+	out, err := translateOpenAIResponse([]byte(openAI), "msg_abc")
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var got anthropicMessagesResponse
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Content) != 2 {
+		t.Fatalf("want 2 blocks [thinking, tool_use], got %d: %+v", len(got.Content), got.Content)
+	}
+	if got.Content[0].Type != "thinking" {
+		t.Errorf("content[0].type = %q, want thinking", got.Content[0].Type)
+	}
+	if got.Content[1].Type != "tool_use" {
+		t.Errorf("content[1].type = %q, want tool_use", got.Content[1].Type)
+	}
+	if got.StopReason != "tool_use" {
+		t.Errorf("stop_reason = %q, want tool_use", got.StopReason)
 	}
 }

--- a/internal/proxy/anthropic_test.go
+++ b/internal/proxy/anthropic_test.go
@@ -378,7 +378,7 @@ func TestTranslateAnthropicStream_HappyPath(t *testing.T) {
 		"event: content_block_stop",
 		"event: message_delta",
 		`"stop_reason":"end_turn"`,
-		`"input_tokens":5`,
+		// Per Anthropic spec, message_delta.usage carries only output_tokens.
 		`"output_tokens":2`,
 		"event: message_stop",
 	}
@@ -460,5 +460,613 @@ func TestCountAnthropicTokens_IncludesSystemAndBlocks(t *testing.T) {
 	}
 	if n != 6 {
 		t.Errorf("count = %d, want 6", n)
+	}
+}
+
+// --- Streaming spec-shape lock-ins ---
+
+// Decodes the SSE stream output into a slice of {event, data} records so
+// tests can assert shape at the JSON-object level instead of substring
+// hunting. The data string still holds the raw JSON payload.
+type sseEvent struct {
+	name string
+	data string
+}
+
+func decodeSSE(t *testing.T, raw string) []sseEvent {
+	t.Helper()
+	var events []sseEvent
+	for _, block := range strings.Split(raw, "\n\n") {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+		var ev sseEvent
+		for _, line := range strings.Split(block, "\n") {
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				ev.name = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				ev.data = strings.TrimPrefix(line, "data: ")
+			}
+		}
+		if ev.name != "" {
+			events = append(events, ev)
+		}
+	}
+	return events
+}
+
+func findEvent(events []sseEvent, name string) *sseEvent {
+	for i := range events {
+		if events[i].name == name {
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+// content_block_start must carry the documented Anthropic shape:
+// {"type":"text","text":""}. The empty text key is required — Python/TS
+// SDK accumulators construct a TextBlock from this event and assume it.
+func TestTranslateAnthropicStream_ContentBlockStartShape(t *testing.T) {
+	upstream := "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"x\"}}]}\n\ndata: [DONE]\n\n"
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(upstream), "msg", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	ev := findEvent(decodeSSE(t, buf.String()), "content_block_start")
+	if ev == nil {
+		t.Fatal("no content_block_start emitted")
+	}
+	var payload struct {
+		Type         string `json:"type"`
+		Index        int    `json:"index"`
+		ContentBlock struct {
+			Type string  `json:"type"`
+			Text *string `json:"text"` // pointer so we can tell "missing" from ""
+		} `json:"content_block"`
+	}
+	if err := json.Unmarshal([]byte(ev.data), &payload); err != nil {
+		t.Fatalf("decode: %v\ndata=%s", err, ev.data)
+	}
+	if payload.ContentBlock.Type != "text" {
+		t.Errorf("content_block.type = %q, want text", payload.ContentBlock.Type)
+	}
+	if payload.ContentBlock.Text == nil {
+		t.Error(`content_block.text missing; Anthropic spec requires text:""`)
+	} else if *payload.ContentBlock.Text != "" {
+		t.Errorf(`content_block.text = %q, want ""`, *payload.ContentBlock.Text)
+	}
+}
+
+// Per spec, message_delta.usage carries only output_tokens (cumulative).
+// input_tokens belongs in message_start and must NOT appear here.
+func TestTranslateAnthropicStream_MessageDeltaUsageShape(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"index":0,"delta":{"content":"x"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":1,"total_tokens":8}}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(upstream), "msg", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	ev := findEvent(decodeSSE(t, buf.String()), "message_delta")
+	if ev == nil {
+		t.Fatal("no message_delta emitted")
+	}
+	var payload struct {
+		Usage map[string]any `json:"usage"`
+	}
+	if err := json.Unmarshal([]byte(ev.data), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, present := payload.Usage["input_tokens"]; present {
+		t.Errorf("message_delta.usage must not contain input_tokens; got %v", payload.Usage)
+	}
+	if payload.Usage["output_tokens"] != float64(1) {
+		t.Errorf("output_tokens = %v, want 1", payload.Usage["output_tokens"])
+	}
+}
+
+// message_start always carries usage with input_tokens — we emit 0 as a
+// known limitation (prompt_tokens aren't known until the final usage chunk,
+// too late to backfill without buffering the whole stream).
+func TestTranslateAnthropicStream_MessageStartUsageZero(t *testing.T) {
+	upstream := "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"x\"}}]}\n\ndata: [DONE]\n\n"
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(upstream), "msg", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	ev := findEvent(decodeSSE(t, buf.String()), "message_start")
+	if ev == nil {
+		t.Fatal("no message_start emitted")
+	}
+	var payload struct {
+		Message struct {
+			ID           string  `json:"id"`
+			Type         string  `json:"type"`
+			Role         string  `json:"role"`
+			Model        string  `json:"model"`
+			StopReason   *string `json:"stop_reason"`
+			StopSequence *string `json:"stop_sequence"`
+			Usage        struct {
+				InputTokens  *int `json:"input_tokens"`
+				OutputTokens *int `json:"output_tokens"`
+			} `json:"usage"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(ev.data), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload.Message.ID != "msg" || payload.Message.Type != "message" || payload.Message.Role != "assistant" {
+		t.Errorf("message_start skeleton wrong: %+v", payload.Message)
+	}
+	if payload.Message.Usage.InputTokens == nil {
+		t.Fatal("message_start.usage.input_tokens missing; spec requires the key present")
+	}
+	// Currently 0 by design (see package-level known limitations). If a
+	// buffering strategy lands, this assertion is the signal to update the
+	// docs and the test together — it's the whole point of the lock-in.
+	if *payload.Message.Usage.InputTokens != 0 {
+		t.Errorf("message_start.usage.input_tokens = %d; documented as 0 — update docs + this test if buffering intentionally landed",
+			*payload.Message.Usage.InputTokens)
+	}
+}
+
+// An upstream chunk that carries both `content` and `finish_reason` on the
+// same choice must still emit the content delta AND the final stop_reason.
+func TestTranslateAnthropicStream_ContentAndFinishOnSameChunk(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"index":0,"delta":{"content":"bye"},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(upstream), "msg", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	events := decodeSSE(t, buf.String())
+	if findEvent(events, "content_block_delta") == nil {
+		t.Error("content_block_delta missing when content arrived alongside finish_reason")
+	}
+	md := findEvent(events, "message_delta")
+	if md == nil || !strings.Contains(md.data, `"stop_reason":"end_turn"`) {
+		t.Errorf("message_delta.stop_reason not end_turn: %+v", md)
+	}
+}
+
+// Malformed or adversarial upstream: two finish chunks. Must emit exactly
+// one message_stop and one message_delta; state must not double-emit.
+func TestTranslateAnthropicStream_MultipleFinishChunks(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"index":0,"delta":{"content":"a"},"finish_reason":"stop"}]}`,
+		`data: {"choices":[{"index":0,"delta":{"content":"b"},"finish_reason":"length"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(upstream), "msg", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	events := decodeSSE(t, buf.String())
+	countEv := func(name string) int {
+		n := 0
+		for _, e := range events {
+			if e.name == name {
+				n++
+			}
+		}
+		return n
+	}
+	if got := countEv("message_stop"); got != 1 {
+		t.Errorf("message_stop count = %d, want 1", got)
+	}
+	if got := countEv("message_delta"); got != 1 {
+		t.Errorf("message_delta count = %d, want 1", got)
+	}
+	// Which stop_reason wins is unspecified for this pathological input —
+	// only the frame-count invariant matters. We intentionally don't pin
+	// first-vs-last here.
+}
+
+// --- Request-side: forward-compat and rejection coverage ---
+
+// A trailing assistant message (prefill) is a legitimate Anthropic pattern;
+// the translator must pass it through so the backend can continue from it.
+func TestTranslateAnthropicRequest_PrefillAssistantPassedThrough(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 20,
+		"messages": [
+			{"role": "user", "content": "begin"},
+			{"role": "assistant", "content": "ok, here we go:"}
+		]
+	}`)
+	out, _, err := translateAnthropicRequest(in)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var got openAIChatRequest
+	_ = json.Unmarshal(out, &got)
+	if len(got.Messages) != 2 {
+		t.Fatalf("got %d messages, want 2", len(got.Messages))
+	}
+	if got.Messages[1].Role != "assistant" {
+		t.Errorf("second message role = %q, want assistant (prefill)", got.Messages[1].Role)
+	}
+}
+
+// Prompt-caching fields (cache_control on system blocks) must not cause a 400.
+// We silently ignore them; clients that always attach them still work.
+func TestTranslateAnthropicRequest_CacheControlOnSystemIgnored(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 5,
+		"system": [
+			{"type": "text", "text": "hello", "cache_control": {"type": "ephemeral"}}
+		],
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	if _, _, err := translateAnthropicRequest(in); err != nil {
+		t.Fatalf("cache_control on system should be ignored, got: %v", err)
+	}
+}
+
+// cache_control on a text content block must not cause a 400.
+func TestTranslateAnthropicRequest_CacheControlOnContentIgnored(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 5,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "cached bit", "cache_control": {"type": "ephemeral"}}
+			]
+		}]
+	}`)
+	if _, _, err := translateAnthropicRequest(in); err != nil {
+		t.Fatalf("cache_control on content should be ignored, got: %v", err)
+	}
+}
+
+// Unknown top-level fields (service_tier, metadata, thinking, container)
+// must be silently ignored for forward-compat with newer API shapes.
+func TestTranslateAnthropicRequest_UnknownTopLevelFieldsIgnored(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 5,
+		"service_tier": "standard_only",
+		"metadata": {"user_id": "u_123"},
+		"container": "c_abc",
+		"thinking": {"type": "enabled"},
+		"cache_control": {"type": "ephemeral"},
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	if _, _, err := translateAnthropicRequest(in); err != nil {
+		t.Fatalf("unknown top-level fields should be ignored, got: %v", err)
+	}
+}
+
+// Document content blocks aren't supported by our translator (backend can't
+// consume them anyway). Reject with a clear 400 mentioning the type.
+func TestTranslateAnthropicRequest_DocumentBlockRejected(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 5,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "document", "source": {"type": "base64", "media_type": "application/pdf", "data": "AAA="}}
+			]
+		}]
+	}`)
+	_, _, err := translateAnthropicRequest(in)
+	var te *translateError
+	if !errors.As(err, &te) || te.status != 400 {
+		t.Fatalf("got err %v, want 400", err)
+	}
+	if !strings.Contains(te.msg, "document") {
+		t.Errorf("error should mention block type; got %q", te.msg)
+	}
+}
+
+// Extended-thinking blocks and redacted_thinking blocks are not translated.
+func TestTranslateAnthropicRequest_ThinkingBlockRejected(t *testing.T) {
+	for _, blockType := range []string{"thinking", "redacted_thinking"} {
+		t.Run(blockType, func(t *testing.T) {
+			body := []byte(`{
+				"model": "m",
+				"max_tokens": 5,
+				"messages": [{
+					"role": "assistant",
+					"content": [{"type": "` + blockType + `", "thinking": "..."}]
+				}]
+			}`)
+			_, _, err := translateAnthropicRequest(body)
+			var te *translateError
+			if !errors.As(err, &te) || te.status != 400 {
+				t.Fatalf("got err %v, want 400", err)
+			}
+			// Make sure we fail for the right reason — not an unrelated
+			// 400 that happens to match status.
+			if !strings.Contains(te.msg, blockType) {
+				t.Errorf("error message should mention %q; got %q", blockType, te.msg)
+			}
+		})
+	}
+}
+
+// Vision URL sources aren't yet supported (only base64). Ensure clients
+// passing {type:"url", url:"..."} get a clear error rather than silent
+// malformation.
+func TestTranslateAnthropicRequest_ImageURLSourceRejected(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 5,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "image", "source": {"type": "url", "url": "https://example.com/x.png"}}
+			]
+		}]
+	}`)
+	_, _, err := translateAnthropicRequest(in)
+	var te *translateError
+	if !errors.As(err, &te) || te.status != 400 {
+		t.Fatalf("got err %v, want 400", err)
+	}
+	if !strings.Contains(te.msg, "base64") {
+		t.Errorf("error message should mention base64: %q", te.msg)
+	}
+}
+
+// tool_choice without tools should still be rejected (consistency — the
+// path is conceptually tool-related either way).
+func TestTranslateAnthropicRequest_ToolChoiceWithoutToolsRejected(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 5,
+		"tool_choice": {"type": "auto"},
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	_, _, err := translateAnthropicRequest(in)
+	var te *translateError
+	if !errors.As(err, &te) || te.status != 400 {
+		t.Fatalf("got err %v, want 400", err)
+	}
+}
+
+// System array containing an image (or any non-text) block must be rejected;
+// Anthropic system is text-only.
+func TestTranslateAnthropicRequest_SystemWithNonTextBlockRejected(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 5,
+		"system": [{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAA="}}],
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	_, _, err := translateAnthropicRequest(in)
+	var te *translateError
+	if !errors.As(err, &te) || te.status != 400 {
+		t.Fatalf("got err %v, want 400", err)
+	}
+}
+
+// Content-block ordering is significant (image before text, text before
+// image) — verify the translator preserves the order the client sent.
+func TestTranslateAnthropicRequest_ContentBlockOrderPreserved(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 5,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAA="}},
+				{"type": "text", "text": "what is this?"}
+			]
+		}]
+	}`)
+	out, _, err := translateAnthropicRequest(in)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var got openAIChatRequest
+	_ = json.Unmarshal(out, &got)
+	var parts []openAIContentPart
+	_ = json.Unmarshal(got.Messages[0].Content, &parts)
+	if len(parts) != 2 {
+		t.Fatalf("parts = %d, want 2", len(parts))
+	}
+	if parts[0].Type != "image_url" || parts[1].Type != "text" {
+		t.Errorf("order not preserved: %+v", parts)
+	}
+}
+
+// --- Response: multi-choice and error shape ---
+
+// Only the first OpenAI choice should populate the Anthropic response;
+// subsequent choices must be dropped rather than concatenated.
+func TestTranslateOpenAIResponse_MultipleChoicesTakesFirst(t *testing.T) {
+	openAI := `{
+		"id": "c",
+		"model": "m",
+		"choices": [
+			{"index": 0, "message": {"role": "assistant", "content": "first"}, "finish_reason": "stop"},
+			{"index": 1, "message": {"role": "assistant", "content": "second"}, "finish_reason": "stop"}
+		],
+		"usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+	}`
+	out, err := translateOpenAIResponse([]byte(openAI), "msg_1")
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var got anthropicMessagesResponse
+	_ = json.Unmarshal(out, &got)
+	if len(got.Content) != 1 || got.Content[0].Text != "first" {
+		t.Errorf("response should carry only first choice; got %+v", got.Content)
+	}
+	// Explicitly guard against a future "concat choices" refactor.
+	if strings.Contains(string(out), "second") {
+		t.Errorf("response leaked choice[1] text; got: %s", string(out))
+	}
+}
+
+// AnthropicError marshalling: the top-level request_id field is what clients
+// correlate with. Ensure it survives serialization.
+func TestAnthropicError_RequestIDInBody(t *testing.T) {
+	e := AnthropicError{
+		Type:      "error",
+		RequestID: "req_abc123",
+		Error: AnthropicErrorDetail{
+			Type:    AnthropicInvalidRequest,
+			Message: "oops",
+		},
+	}
+	raw, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["request_id"] != "req_abc123" {
+		t.Errorf("request_id not present in marshalled error body; got %+v", got)
+	}
+	errMap, ok := got["error"].(map[string]any)
+	if !ok || errMap["type"] != string(AnthropicInvalidRequest) {
+		t.Errorf("error.type wrong: %+v", got["error"])
+	}
+}
+
+// Empty messages array: we don't auto-reject (let the backend complain if
+// it cares). Lock in this behavior so a change is deliberate.
+func TestTranslateAnthropicRequest_EmptyMessagesAccepted(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 5,
+		"messages": []
+	}`)
+	if _, _, err := translateAnthropicRequest(in); err != nil {
+		t.Fatalf("empty messages should translate without error; got: %v", err)
+	}
+}
+
+// count_tokens must reject tools for consistency with /v1/messages — and
+// because tool schemas contribute substantial tokens that our char-ratio
+// approximation would silently undercount, leading to context overflows.
+func TestCountAnthropicTokens_ToolsRejected(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"tools": [{"name": "f", "description": "d", "input_schema": {}}],
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	_, err := countAnthropicTokens(in)
+	var te *translateError
+	if !errors.As(err, &te) || te.status != 400 {
+		t.Fatalf("got err %v, want 400 for tools in count_tokens", err)
+	}
+}
+
+// Upstream error chunks are translated to Anthropic `event: error` frames.
+// After that, no further content or message_* frames should be emitted.
+func TestTranslateAnthropicStream_UpstreamErrorBecomesErrorEvent(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"index":0,"delta":{"content":"hi"}}]}`,
+		`data: {"error":{"message":"backend exploded","type":"api_error"}}`,
+		// A spurious trailing chunk after the error must not produce output.
+		`data: {"choices":[{"index":0,"delta":{"content":"never"}}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(upstream), "msg", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	events := decodeSSE(t, buf.String())
+
+	errEv := findEvent(events, "error")
+	if errEv == nil {
+		t.Fatal("expected event: error to be emitted on upstream error")
+	}
+	if !strings.Contains(errEv.data, "backend exploded") {
+		t.Errorf("error event missing upstream message; got: %s", errEv.data)
+	}
+
+	// After the error, we must not emit message_delta/message_stop — that
+	// would confuse clients about the final state.
+	for _, name := range []string{"message_delta", "message_stop"} {
+		if findEvent(events, name) != nil {
+			t.Errorf("%s must not follow an error event", name)
+		}
+	}
+	// Content from after the error chunk must not be present.
+	if strings.Contains(buf.String(), "never") {
+		t.Errorf("content after error should not be forwarded")
+	}
+}
+
+// Event ordering: content_block_start must precede the first
+// content_block_delta. The ensureStarted guard is load-bearing; a
+// regression here would break every strict SDK accumulator.
+func TestTranslateAnthropicStream_EventOrdering(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"choices":[{"index":0,"delta":{"content":"A"}}]}`,
+		`data: {"choices":[{"index":0,"delta":{"content":"B"},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(upstream), "msg", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	events := decodeSSE(t, buf.String())
+
+	indexOf := func(name string) int {
+		for i, e := range events {
+			if e.name == name {
+				return i
+			}
+		}
+		return -1
+	}
+	var (
+		iStart = indexOf("message_start")
+		iCBS   = indexOf("content_block_start")
+		iCBD   = indexOf("content_block_delta")
+		iCBE   = indexOf("content_block_stop")
+		iMD    = indexOf("message_delta")
+		iMS    = indexOf("message_stop")
+	)
+	if iStart < 0 || iCBS < 0 || iCBD < 0 || iCBE < 0 || iMD < 0 || iMS < 0 {
+		t.Fatalf("missing event; got order: %+v", events)
+	}
+	// Canonical Anthropic order.
+	if iStart >= iCBS || iCBS >= iCBD || iCBD >= iCBE || iCBE >= iMD || iMD >= iMS {
+		t.Errorf("out-of-order events: start=%d cbs=%d cbd=%d cbe=%d md=%d ms=%d", iStart, iCBS, iCBD, iCBE, iMD, iMS)
+	}
+}
+
+// stop_sequence must serialize as null (not omitted) on non-streaming
+// responses. We never know which sequence matched — see known limitations
+// — so emitting null is the honest, spec-compliant signal.
+func TestTranslateOpenAIResponse_StopSequenceNullPresent(t *testing.T) {
+	openAI := `{
+		"id": "c",
+		"model": "m",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+		"usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+	}`
+	out, err := translateOpenAIResponse([]byte(openAI), "msg_x")
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	// Substring check — we want the literal `"stop_sequence":null` key to
+	// be present, not omitted. A struct decode would silently hide omission.
+	if !strings.Contains(string(out), `"stop_sequence":null`) {
+		t.Errorf(`response should include "stop_sequence":null key; got %s`, string(out))
 	}
 }

--- a/internal/proxy/anthropic_test.go
+++ b/internal/proxy/anthropic_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -128,20 +129,58 @@ func TestTranslateAnthropicRequest_SystemArrayFlattened(t *testing.T) {
 	}
 }
 
-func TestTranslateAnthropicRequest_ToolUseAssistantContentRejected(t *testing.T) {
+// Assistant tool_use blocks translate to an OpenAI assistant message with
+// tool_calls — Anthropic's {id, name, input} maps 1:1 to OpenAI's
+// {id, type:"function", function:{name, arguments}}.
+func TestTranslateAnthropicRequest_AssistantToolUseTranslated(t *testing.T) {
 	in := []byte(`{
 		"model": "m",
 		"max_tokens": 10,
 		"messages": [{
 			"role": "assistant",
-			"content": [{"type": "tool_use", "id": "t1", "name": "f", "input": {}}]
+			"content": [
+				{"type": "text", "text": "thinking..."},
+				{"type": "tool_use", "id": "t1", "name": "fetch", "input": {"url": "https://x"}}
+			]
 		}]
 	}`)
 
-	_, _, err := translateAnthropicRequest(in)
-	var te *translateError
-	if !errors.As(err, &te) || te.status != 400 {
-		t.Fatalf("got err %v, want 400 translateError", err)
+	out, _, err := translateAnthropicRequest(in)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var got struct {
+		Messages []struct {
+			Role      string `json:"role"`
+			Content   string `json:"content"`
+			ToolCalls []struct {
+				ID       string `json:"id"`
+				Type     string `json:"type"`
+				Function struct {
+					Name, Arguments string
+				} `json:"function"`
+			} `json:"tool_calls"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(got.Messages) != 1 {
+		t.Fatalf("messages = %d, want 1", len(got.Messages))
+	}
+	m := got.Messages[0]
+	if m.Role != "assistant" || m.Content != "thinking..." {
+		t.Errorf("role/content: %q %q", m.Role, m.Content)
+	}
+	if len(m.ToolCalls) != 1 {
+		t.Fatalf("tool_calls = %d, want 1", len(m.ToolCalls))
+	}
+	tc := m.ToolCalls[0]
+	if tc.ID != "t1" || tc.Type != "function" || tc.Function.Name != "fetch" {
+		t.Errorf("tool call shape: %+v", tc)
+	}
+	if !strings.Contains(tc.Function.Arguments, `"url"`) {
+		t.Errorf("arguments lost input: %q", tc.Function.Arguments)
 	}
 }
 
@@ -262,38 +301,165 @@ func TestTranslateAnthropicRequest_ContentBlocksTextAndImage(t *testing.T) {
 	}
 }
 
-func TestTranslateAnthropicRequest_ToolsRejected(t *testing.T) {
+// Tools are translated into OpenAI's tools schema: Anthropic's
+// {name, description, input_schema} becomes {type:"function", function:
+// {name, description, parameters}}. Clients like Claude Code / aider
+// / cline rely on this; without it they can't use the proxy at all.
+func TestTranslateAnthropicRequest_ToolsTranslated(t *testing.T) {
 	in := []byte(`{
 		"model": "m",
 		"max_tokens": 10,
-		"tools": [{"name": "get_weather"}],
+		"tools": [{
+			"name": "get_weather",
+			"description": "Return the weather",
+			"input_schema": {"type": "object", "properties": {"loc": {"type": "string"}}}
+		}],
 		"messages": [{"role": "user", "content": "hi"}]
 	}`)
-
-	_, _, err := translateAnthropicRequest(in)
-	var te *translateError
-	if !errors.As(err, &te) || te.status != 400 {
-		t.Fatalf("got err %v, want 400 translateError", err)
+	out, _, err := translateAnthropicRequest(in)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
 	}
-	if !strings.Contains(te.msg, "tools") {
-		t.Errorf("error message = %q, should mention tools", te.msg)
+	var got struct {
+		Tools []struct {
+			Type     string `json:"type"`
+			Function struct {
+				Name, Description string
+				Parameters        map[string]any
+			} `json:"function"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(got.Tools) != 1 {
+		t.Fatalf("tools = %d, want 1", len(got.Tools))
+	}
+	tool := got.Tools[0]
+	if tool.Type != "function" || tool.Function.Name != "get_weather" {
+		t.Errorf("tool shape: %+v", tool)
+	}
+	if tool.Function.Description == "" {
+		t.Errorf("description dropped")
+	}
+	if tool.Function.Parameters["type"] != "object" {
+		t.Errorf("parameters lost: %+v", tool.Function.Parameters)
 	}
 }
 
-func TestTranslateAnthropicRequest_ToolResultContentRejected(t *testing.T) {
-	in := []byte(`{
-		"model": "m",
-		"max_tokens": 10,
-		"messages": [{
-			"role": "user",
-			"content": [{"type": "tool_result", "tool_use_id": "x", "content": "42"}]
-		}]
-	}`)
+// Each tool_choice shape must land on the correct OpenAI form so the
+// backend sees the same intent. Pins the 1:1 mapping — a client sending
+// {type:"any"} expects forced tool use and we must translate to "required",
+// not drop it.
+func TestTranslateAnthropicRequest_ToolChoiceShapes(t *testing.T) {
+	base := func(tc string) []byte {
+		return []byte(`{
+			"model": "m", "max_tokens": 10,
+			"tools": [{"name": "f", "input_schema": {}}],
+			"tool_choice": ` + tc + `,
+			"messages": [{"role": "user", "content": "hi"}]
+		}`)
+	}
+	// Compared after re-parsing so map key order doesn't matter.
+	decode := func(raw string) any {
+		var v any
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			t.Fatalf("decode %s: %v", raw, err)
+		}
+		return v
+	}
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"string auto", `"auto"`, `"auto"`},
+		{"object auto", `{"type":"auto"}`, `"auto"`},
+		{"object any -> required", `{"type":"any"}`, `"required"`},
+		{"object none", `{"type":"none"}`, `"none"`},
+		{"object tool with name", `{"type":"tool","name":"f"}`, `{"type":"function","function":{"name":"f"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, _, err := translateAnthropicRequest(base(tc.in))
+			if err != nil {
+				t.Fatalf("translate: %v", err)
+			}
+			var got struct {
+				ToolChoice json.RawMessage `json:"tool_choice"`
+			}
+			if err := json.Unmarshal(out, &got); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(decode(string(got.ToolChoice)), decode(tc.want)) {
+				t.Errorf("tool_choice = %s, want %s", got.ToolChoice, tc.want)
+			}
+		})
+	}
+}
 
-	_, _, err := translateAnthropicRequest(in)
-	var te *translateError
-	if !errors.As(err, &te) || te.status != 400 {
-		t.Fatalf("got err %v, want 400 translateError", err)
+// Empty tools/tool_choice are treated as absent — a client attaching
+// `tools: []` unconditionally (common Go/Python SDK wrapper pattern) must
+// not be rejected or forced into tool mode.
+func TestTranslateAnthropicRequest_EmptyToolsAreAbsent(t *testing.T) {
+	in := []byte(`{
+		"model": "m", "max_tokens": 10,
+		"tools": [], "tool_choice": {},
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	out, _, err := translateAnthropicRequest(in)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if bytes.Contains(out, []byte(`"tools"`)) {
+		t.Error("empty tools should not appear in translated request")
+	}
+	if bytes.Contains(out, []byte(`"tool_choice"`)) {
+		t.Error("empty tool_choice should not appear in translated request")
+	}
+}
+
+// tool_result content blocks translate to role:"tool" OpenAI messages;
+// this is the end-half of the Claude Code tool loop. Multiple tool_result
+// blocks in one user turn fan out to one OpenAI message each.
+func TestTranslateAnthropicRequest_ToolResultTranslated(t *testing.T) {
+	in := []byte(`{
+		"model": "m", "max_tokens": 10,
+		"messages": [
+			{"role": "assistant", "content": [
+				{"type": "tool_use", "id": "a", "name": "f", "input": {}}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "a", "content": "42"},
+				{"type": "text", "text": "one more thing"}
+			]}
+		]
+	}`)
+	out, _, err := translateAnthropicRequest(in)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var got struct {
+		Messages []struct {
+			Role       string          `json:"role"`
+			Content    json.RawMessage `json:"content"`
+			ToolCallID string          `json:"tool_call_id"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(got.Messages) != 3 {
+		t.Fatalf("messages = %d, want 3 (assistant + tool + user)", len(got.Messages))
+	}
+	if got.Messages[1].Role != "tool" || got.Messages[1].ToolCallID != "a" {
+		t.Errorf("second message: role=%s id=%s, want tool/a", got.Messages[1].Role, got.Messages[1].ToolCallID)
+	}
+	if !bytes.Contains(got.Messages[1].Content, []byte("42")) {
+		t.Errorf("tool content missing: %s", got.Messages[1].Content)
+	}
+	if got.Messages[2].Role != "user" {
+		t.Errorf("third message: role=%s, want user", got.Messages[2].Role)
 	}
 }
 
@@ -411,6 +577,196 @@ func TestTranslateAnthropicStream_EmptyUpstreamStillEmitsFrame(t *testing.T) {
 	}
 }
 
+// When llama-server reports a stopping_word on a finish_reason=="stop",
+// translate to Anthropic's stop_reason="stop_sequence" with the matched
+// string carried on stop_sequence. Without this, clients that branch on
+// "stop_sequence" (e.g. aider-style multi-model agents) never see the
+// signal.
+func TestTranslateOpenAIResponse_StopSequenceForwarded(t *testing.T) {
+	openAI := `{
+		"model": "m",
+		"choices": [{
+			"index": 0,
+			"message": {"role": "assistant", "content": "stop here"},
+			"finish_reason": "stop",
+			"stopping_word": "\nHuman:"
+		}],
+		"usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}
+	}`
+	out, err := translateOpenAIResponse([]byte(openAI), "msg_abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got anthropicMessagesResponse
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.StopReason != "stop_sequence" {
+		t.Errorf("stop_reason = %q, want stop_sequence", got.StopReason)
+	}
+	if got.StopSequence == nil || *got.StopSequence != "\nHuman:" {
+		t.Errorf("stop_sequence = %v, want \\nHuman:", got.StopSequence)
+	}
+}
+
+// An OpenAI response with finish_reason="tool_calls" must produce an
+// Anthropic response whose content includes tool_use blocks and whose
+// stop_reason is "tool_use" — the contract Claude Code's tool loop walks.
+func TestTranslateOpenAIResponse_ToolCalls(t *testing.T) {
+	openAI := `{
+		"model": "m",
+		"choices": [{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"content": "",
+				"tool_calls": [{
+					"id": "call_1",
+					"type": "function",
+					"function": {"name": "fetch", "arguments": "{\"url\":\"https://x\"}"}
+				}]
+			},
+			"finish_reason": "tool_calls"
+		}],
+		"usage": {"prompt_tokens": 10, "completion_tokens": 8, "total_tokens": 18}
+	}`
+	out, err := translateOpenAIResponse([]byte(openAI), "msg_abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got anthropicMessagesResponse
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.StopReason != "tool_use" {
+		t.Errorf("stop_reason = %q, want tool_use", got.StopReason)
+	}
+	if len(got.Content) != 1 || got.Content[0].Type != "tool_use" {
+		t.Fatalf("content shape: %+v", got.Content)
+	}
+	if got.Content[0].ID != "call_1" || got.Content[0].Name != "fetch" {
+		t.Errorf("tool_use fields: %+v", got.Content[0])
+	}
+	var input map[string]any
+	if err := json.Unmarshal(got.Content[0].Input, &input); err != nil {
+		t.Fatalf("input parse: %v", err)
+	}
+	if input["url"] != "https://x" {
+		t.Errorf("input lost arguments: %+v", input)
+	}
+}
+
+// Streaming: tool_call deltas must produce content_block_start with
+// content_block.type="tool_use" and input_json_delta partial_json events
+// that SDK accumulators stitch back into a JSON argument object.
+func TestTranslateAnthropicStream_ToolCallDeltas(t *testing.T) {
+	upstream := strings.Join([]string{
+		// First chunk introduces the tool call (id + name)
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"fetch","arguments":""}}]}}]}`,
+		// Args arrive in two fragments
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"url\":"}}]}}]}`,
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"https://x\"}"}}]}}]}`,
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(upstream), "msg", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	events := decodeSSE(t, buf.String())
+
+	// message_start present, tool_use block_start present, at least two
+	// input_json_delta events, one block_stop, stop_reason tool_use.
+	var blockStartFound, blockStopFound bool
+	var partialJSON []string
+	var stopReason string
+	for _, ev := range events {
+		switch ev.name {
+		case "content_block_start":
+			if strings.Contains(ev.data, `"type":"tool_use"`) {
+				blockStartFound = true
+				if !strings.Contains(ev.data, `"id":"call_1"`) {
+					t.Errorf("tool block_start missing id: %s", ev.data)
+				}
+				if !strings.Contains(ev.data, `"name":"fetch"`) {
+					t.Errorf("tool block_start missing name: %s", ev.data)
+				}
+			}
+		case "content_block_delta":
+			if strings.Contains(ev.data, `"type":"input_json_delta"`) {
+				var payload struct {
+					Delta struct {
+						Partial string `json:"partial_json"`
+					} `json:"delta"`
+				}
+				_ = json.Unmarshal([]byte(ev.data), &payload)
+				partialJSON = append(partialJSON, payload.Delta.Partial)
+			}
+		case "content_block_stop":
+			blockStopFound = true
+		case "message_delta":
+			if strings.Contains(ev.data, `"stop_reason":"tool_use"`) {
+				stopReason = "tool_use"
+			}
+		}
+	}
+	if !blockStartFound {
+		t.Error("missing tool_use content_block_start")
+	}
+	if !blockStopFound {
+		t.Error("missing content_block_stop")
+	}
+	if stopReason != "tool_use" {
+		t.Error("message_delta did not report stop_reason=tool_use")
+	}
+	if len(partialJSON) < 2 {
+		t.Errorf("expected ≥2 input_json_delta events, got %d: %v", len(partialJSON), partialJSON)
+	}
+	// The concatenated fragments must be a valid JSON object.
+	joined := strings.Join(partialJSON, "")
+	var args map[string]any
+	if err := json.Unmarshal([]byte(joined), &args); err != nil {
+		t.Errorf("concatenated partial_json not valid JSON: %v (got %q)", err, joined)
+	}
+}
+
+// Upstream error events with a non-Anthropic type must be normalized to the
+// api_error enum so SDK consumers don't see a leaked backend-specific type.
+func TestTranslateAnthropicStream_ErrorTypeNormalized(t *testing.T) {
+	upstream := `data: {"error":{"message":"boom","type":"VendorSpecificError"}}` + "\n\n"
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(upstream), "msg", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	for _, ev := range decodeSSE(t, buf.String()) {
+		if ev.name != "error" {
+			continue
+		}
+		if !strings.Contains(ev.data, `"type":"api_error"`) {
+			t.Errorf("error type not normalized: %s", ev.data)
+		}
+	}
+}
+
+// generateMessageID must produce values independent of request IDs and
+// the required msg_ prefix. We call it N times and require uniqueness —
+// a regression where it derives from the request ID would collide when
+// called twice in quick succession with the same request.
+func TestGenerateMessageID(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 16; i++ {
+		id := generateMessageID()
+		if !strings.HasPrefix(id, "msg_") {
+			t.Errorf("id missing prefix: %q", id)
+		}
+		if seen[id] {
+			t.Errorf("duplicate id: %q", id)
+		}
+		seen[id] = true
+	}
+}
+
 func TestTranslateAnthropicStream_MappedFinishReason(t *testing.T) {
 	upstream := strings.Join([]string{
 		`data: {"id":"c","model":"m","choices":[{"index":0,"delta":{"content":"x"},"finish_reason":"length"}]}`,
@@ -426,8 +782,11 @@ func TestTranslateAnthropicStream_MappedFinishReason(t *testing.T) {
 	}
 }
 
+// countAnthropicTokens is deliberately conservative (overcount). We don't
+// pin exact numbers because the estimator is tuned for planning safety, not
+// parity with a real tokenizer — instead we assert sane ranges plus the
+// invariant that additional content never decreases the count.
 func TestCountAnthropicTokens(t *testing.T) {
-	// A 7-char string should yield ceil(7/3.5) = 2 tokens.
 	body := []byte(`{
 		"model": "m",
 		"messages": [{"role": "user", "content": "abcdefg"}]
@@ -436,30 +795,33 @@ func TestCountAnthropicTokens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("count: %v", err)
 	}
-	if n != 2 {
-		t.Errorf("count = %d, want 2", n)
+	// 7 chars → at least 3 content tokens, plus per-message overhead.
+	// Upper bound guards against a runaway estimator.
+	if n < 3 || n > 20 {
+		t.Errorf("count = %d, want 3 ≤ n ≤ 20", n)
 	}
 }
 
-func TestCountAnthropicTokens_IncludesSystemAndBlocks(t *testing.T) {
-	body := []byte(`{
+// Adding system content and content blocks must never reduce the estimate.
+// Regression guard: the old estimator silently dropped the per-message
+// overhead, letting a longer request appear cheaper than a shorter one.
+func TestCountAnthropicTokens_MonotonicInContent(t *testing.T) {
+	small := []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}]}`)
+	big := []byte(`{
 		"model": "m",
-		"system": "abcdefg",
-		"messages": [{
-			"role": "user",
-			"content": [
+		"system": "you are helpful",
+		"messages": [
+			{"role": "user", "content": [
 				{"type": "text", "text": "hijklmn"},
 				{"type": "text", "text": "opqrstu"}
-			]
-		}]
+			]},
+			{"role": "assistant", "content": "ack"}
+		]
 	}`)
-	// 3 segments × 7 chars → ceil(7/3.5)=2 tokens each → 6 total.
-	n, err := countAnthropicTokens(body)
-	if err != nil {
-		t.Fatalf("count: %v", err)
-	}
-	if n != 6 {
-		t.Errorf("count = %d, want 6", n)
+	nSmall, _ := countAnthropicTokens(small)
+	nBig, _ := countAnthropicTokens(big)
+	if nBig <= nSmall {
+		t.Errorf("big request not larger: small=%d big=%d", nSmall, nBig)
 	}
 }
 
@@ -772,8 +1134,11 @@ func TestTranslateAnthropicRequest_DocumentBlockRejected(t *testing.T) {
 	}
 }
 
-// Extended-thinking blocks and redacted_thinking blocks are not translated.
-func TestTranslateAnthropicRequest_ThinkingBlockRejected(t *testing.T) {
+// Extended-thinking and redacted_thinking blocks are advisory; we drop
+// them from the translated request rather than reject, so an assistant
+// turn that carries them (from an earlier round with a reasoning-enabled
+// model) still gets through to backends that don't understand them.
+func TestTranslateAnthropicRequest_ThinkingBlockDropped(t *testing.T) {
 	for _, blockType := range []string{"thinking", "redacted_thinking"} {
 		t.Run(blockType, func(t *testing.T) {
 			body := []byte(`{
@@ -781,27 +1146,32 @@ func TestTranslateAnthropicRequest_ThinkingBlockRejected(t *testing.T) {
 				"max_tokens": 5,
 				"messages": [{
 					"role": "assistant",
-					"content": [{"type": "` + blockType + `", "thinking": "..."}]
+					"content": [
+						{"type": "` + blockType + `", "thinking": "secret"},
+						{"type": "text", "text": "final answer"}
+					]
 				}]
 			}`)
-			_, _, err := translateAnthropicRequest(body)
-			var te *translateError
-			if !errors.As(err, &te) || te.status != 400 {
-				t.Fatalf("got err %v, want 400", err)
+			out, _, err := translateAnthropicRequest(body)
+			if err != nil {
+				t.Fatalf("thinking block should be dropped, got err: %v", err)
 			}
-			// Make sure we fail for the right reason — not an unrelated
-			// 400 that happens to match status.
-			if !strings.Contains(te.msg, blockType) {
-				t.Errorf("error message should mention %q; got %q", blockType, te.msg)
+			// The thinking text must not leak into the backend request;
+			// only the surrounding text block remains.
+			if bytes.Contains(out, []byte("secret")) {
+				t.Errorf("thinking content leaked into translated request: %s", out)
+			}
+			if !bytes.Contains(out, []byte("final answer")) {
+				t.Errorf("surrounding text dropped: %s", out)
 			}
 		})
 	}
 }
 
-// Anthropic supports `source.type: "url"` for images (added 2024); llama.cpp
-// passes the URL through verbatim. We do the same — no download, no
-// validation; let the backend fetch.
-func TestTranslateAnthropicRequest_ImageURLSourcePassthrough(t *testing.T) {
+// Anthropic supports `source.type: "url"` for images, but llama-server and
+// SwiftLM don't fetch URLs at load time — passing one through would surface
+// as an opaque backend error. We reject with a clear actionable message.
+func TestTranslateAnthropicRequest_ImageURLSourceRejected(t *testing.T) {
 	in := []byte(`{
 		"model": "m",
 		"max_tokens": 5,
@@ -812,19 +1182,13 @@ func TestTranslateAnthropicRequest_ImageURLSourcePassthrough(t *testing.T) {
 			]
 		}]
 	}`)
-	out, _, err := translateAnthropicRequest(in)
-	if err != nil {
-		t.Fatalf("url image should be accepted, got: %v", err)
+	_, _, err := translateAnthropicRequest(in)
+	var te *translateError
+	if !errors.As(err, &te) || te.status != 400 {
+		t.Fatalf("got err %v, want 400", err)
 	}
-	var got openAIChatRequest
-	_ = json.Unmarshal(out, &got)
-	var parts []openAIContentPart
-	_ = json.Unmarshal(got.Messages[0].Content, &parts)
-	if len(parts) != 1 || parts[0].ImageURL == nil {
-		t.Fatalf("expected one image_url part; got %+v", parts)
-	}
-	if parts[0].ImageURL.URL != "https://example.com/x.png" {
-		t.Errorf("image url = %q, want passthrough", parts[0].ImageURL.URL)
+	if !strings.Contains(te.msg, "url sources") {
+		t.Errorf("error should explain the URL rejection; got %q", te.msg)
 	}
 }
 
@@ -979,19 +1343,30 @@ func TestTranslateAnthropicRequest_EmptyMessagesAccepted(t *testing.T) {
 	}
 }
 
-// count_tokens must reject tools for consistency with /v1/messages — and
-// because tool schemas contribute substantial tokens that our char-ratio
-// approximation would silently undercount, leading to context overflows.
-func TestCountAnthropicTokens_ToolsRejected(t *testing.T) {
-	in := []byte(`{
+// count_tokens estimates tool schema cost too — otherwise a client using
+// count_tokens to size its context budget will undercount a tool-heavy
+// request and trip context-window errors at inference time. Hard number
+// pinning is avoided (estimator is heuristic) in favor of an inequality.
+func TestCountAnthropicTokens_IncludesToolSchemas(t *testing.T) {
+	withTools := []byte(`{
 		"model": "m",
-		"tools": [{"name": "f", "description": "d", "input_schema": {}}],
+		"tools": [{"name": "f", "description": "do the thing", "input_schema": {"type":"object","properties":{"x":{"type":"string","description":"the x"}}}}],
 		"messages": [{"role": "user", "content": "hi"}]
 	}`)
-	_, err := countAnthropicTokens(in)
-	var te *translateError
-	if !errors.As(err, &te) || te.status != 400 {
-		t.Fatalf("got err %v, want 400 for tools in count_tokens", err)
+	withoutTools := []byte(`{
+		"model": "m",
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	nWith, err := countAnthropicTokens(withTools)
+	if err != nil {
+		t.Fatalf("with tools: %v", err)
+	}
+	nWithout, err := countAnthropicTokens(withoutTools)
+	if err != nil {
+		t.Fatalf("without: %v", err)
+	}
+	if nWith <= nWithout {
+		t.Errorf("tools didn't add to count: with=%d without=%d", nWith, nWithout)
 	}
 }
 

--- a/internal/proxy/anthropic_test.go
+++ b/internal/proxy/anthropic_test.go
@@ -1,0 +1,464 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestTranslateAnthropicRequest_StringContent(t *testing.T) {
+	in := `{
+		"model": "some/model:Q4",
+		"max_tokens": 64,
+		"messages": [
+			{"role": "user", "content": "hi"}
+		]
+	}`
+
+	out, stream, err := translateAnthropicRequest([]byte(in))
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if stream {
+		t.Errorf("stream = true, want false")
+	}
+
+	var got openAIChatRequest
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decode openai req: %v", err)
+	}
+	if got.Model != "some/model:Q4" {
+		t.Errorf("model = %q, want some/model:Q4", got.Model)
+	}
+	if got.MaxTokens != 64 {
+		t.Errorf("max_tokens = %d, want 64", got.MaxTokens)
+	}
+	if len(got.Messages) != 1 || got.Messages[0].Role != "user" {
+		t.Fatalf("messages = %+v, want 1 user message", got.Messages)
+	}
+
+	var contentStr string
+	if err := json.Unmarshal(got.Messages[0].Content, &contentStr); err != nil {
+		t.Fatalf("content should be string: %v", err)
+	}
+	if contentStr != "hi" {
+		t.Errorf("content = %q, want hi", contentStr)
+	}
+}
+
+func TestTranslateAnthropicRequest_SystemAndSamplingParams(t *testing.T) {
+	temp := 0.4
+	topP := 0.9
+	topK := 40
+	in := anthropicMessagesRequest{
+		Model:         "m",
+		MaxTokens:     32,
+		Temperature:   &temp,
+		TopP:          &topP,
+		TopK:          &topK,
+		StopSequences: []string{"</s>", "<|endoftext|>"},
+		Stream:        true,
+		System:        json.RawMessage(`"Be brief."`),
+		Messages: []anthropicMessage{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+		},
+	}
+	body, _ := json.Marshal(in)
+
+	out, stream, err := translateAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if !stream {
+		t.Errorf("stream = false, want true")
+	}
+
+	var got openAIChatRequest
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Temperature == nil || *got.Temperature != 0.4 {
+		t.Errorf("temperature = %v, want 0.4", got.Temperature)
+	}
+	if got.TopP == nil || *got.TopP != 0.9 {
+		t.Errorf("top_p = %v, want 0.9", got.TopP)
+	}
+	if got.TopK == nil || *got.TopK != 40 {
+		t.Errorf("top_k = %v, want 40", got.TopK)
+	}
+	if len(got.Stop) != 2 || got.Stop[0] != "</s>" {
+		t.Errorf("stop = %v, want [</s>, <|endoftext|>]", got.Stop)
+	}
+	if len(got.Messages) != 2 {
+		t.Fatalf("got %d messages, want 2 (system + user)", len(got.Messages))
+	}
+	if got.Messages[0].Role != "system" {
+		t.Errorf("first message role = %q, want system", got.Messages[0].Role)
+	}
+	var sys string
+	_ = json.Unmarshal(got.Messages[0].Content, &sys)
+	if sys != "Be brief." {
+		t.Errorf("system content = %q, want Be brief.", sys)
+	}
+}
+
+func TestTranslateAnthropicRequest_SystemArrayFlattened(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 10,
+		"system": [
+			{"type": "text", "text": "Part one."},
+			{"type": "text", "text": "Part two."}
+		],
+		"messages": [{"role": "user", "content": "q"}]
+	}`)
+
+	out, _, err := translateAnthropicRequest(in)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var got openAIChatRequest
+	_ = json.Unmarshal(out, &got)
+	var sys string
+	_ = json.Unmarshal(got.Messages[0].Content, &sys)
+	if sys != "Part one.\n\nPart two." {
+		t.Errorf("system = %q, want joined parts", sys)
+	}
+}
+
+func TestTranslateAnthropicRequest_ToolUseAssistantContentRejected(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 10,
+		"messages": [{
+			"role": "assistant",
+			"content": [{"type": "tool_use", "id": "t1", "name": "f", "input": {}}]
+		}]
+	}`)
+
+	_, _, err := translateAnthropicRequest(in)
+	var te *translateError
+	if !errors.As(err, &te) || te.status != 400 {
+		t.Fatalf("got err %v, want 400 translateError", err)
+	}
+}
+
+func TestTranslateAnthropicRequest_MaxTokensRequired(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	_, _, err := translateAnthropicRequest(in)
+	var te *translateError
+	if !errors.As(err, &te) || te.status != 400 {
+		t.Fatalf("got err %v, want 400 translateError for missing max_tokens", err)
+	}
+}
+
+func TestTranslateAnthropicRequest_ToolChoiceNullIsAccepted(t *testing.T) {
+	// A literal null for tools/tool_choice must not be treated as "present".
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 5,
+		"tool_choice": null,
+		"tools": null,
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	if _, _, err := translateAnthropicRequest(in); err != nil {
+		t.Fatalf("null tool_choice/tools should be accepted, got: %v", err)
+	}
+}
+
+func TestTranslateAnthropicRequest_StopSequencesCapped(t *testing.T) {
+	in := anthropicMessagesRequest{
+		Model:         "m",
+		MaxTokens:     5,
+		StopSequences: []string{"a", "b", "c", "d", "e"},
+		Messages:      []anthropicMessage{{Role: "user", Content: json.RawMessage(`"hi"`)}},
+	}
+	body, _ := json.Marshal(in)
+	_, _, err := translateAnthropicRequest(body)
+	var te *translateError
+	if !errors.As(err, &te) || te.status != 400 {
+		t.Fatalf("got err %v, want 400 for too many stop_sequences", err)
+	}
+}
+
+func TestTranslateAnthropicRequest_DisallowedImageMediaType(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 5,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "image", "source": {"type": "base64", "media_type": "image/bmp", "data": "AAAA"}}
+			]
+		}]
+	}`)
+	_, _, err := translateAnthropicRequest(in)
+	var te *translateError
+	if !errors.As(err, &te) || te.status != 400 {
+		t.Fatalf("got err %v, want 400 for disallowed media_type", err)
+	}
+}
+
+func TestTranslateAnthropicRequest_StreamingAsksForUsage(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 10,
+		"stream": true,
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+	out, _, err := translateAnthropicRequest(in)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var got openAIChatRequest
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.StreamOptions == nil || !got.StreamOptions.IncludeUsage {
+		t.Errorf("stream_options.include_usage not set; got %+v", got.StreamOptions)
+	}
+}
+
+func TestTranslateAnthropicRequest_ContentBlocksTextAndImage(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 10,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "describe"},
+				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}}
+			]
+		}]
+	}`)
+
+	out, _, err := translateAnthropicRequest(in)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	var got openAIChatRequest
+	_ = json.Unmarshal(out, &got)
+
+	var parts []openAIContentPart
+	if err := json.Unmarshal(got.Messages[0].Content, &parts); err != nil {
+		t.Fatalf("content should be array: %v", err)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("got %d parts, want 2", len(parts))
+	}
+	if parts[0].Type != "text" || parts[0].Text != "describe" {
+		t.Errorf("parts[0] = %+v", parts[0])
+	}
+	if parts[1].Type != "image_url" || parts[1].ImageURL == nil {
+		t.Fatalf("parts[1] = %+v", parts[1])
+	}
+	if parts[1].ImageURL.URL != "data:image/png;base64,AAAA" {
+		t.Errorf("image url = %q", parts[1].ImageURL.URL)
+	}
+}
+
+func TestTranslateAnthropicRequest_ToolsRejected(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 10,
+		"tools": [{"name": "get_weather"}],
+		"messages": [{"role": "user", "content": "hi"}]
+	}`)
+
+	_, _, err := translateAnthropicRequest(in)
+	var te *translateError
+	if !errors.As(err, &te) || te.status != 400 {
+		t.Fatalf("got err %v, want 400 translateError", err)
+	}
+	if !strings.Contains(te.msg, "tools") {
+		t.Errorf("error message = %q, should mention tools", te.msg)
+	}
+}
+
+func TestTranslateAnthropicRequest_ToolResultContentRejected(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 10,
+		"messages": [{
+			"role": "user",
+			"content": [{"type": "tool_result", "tool_use_id": "x", "content": "42"}]
+		}]
+	}`)
+
+	_, _, err := translateAnthropicRequest(in)
+	var te *translateError
+	if !errors.As(err, &te) || te.status != 400 {
+		t.Fatalf("got err %v, want 400 translateError", err)
+	}
+}
+
+func TestTranslateOpenAIResponse_Basic(t *testing.T) {
+	openAI := `{
+		"id": "chatcmpl-xyz",
+		"model": "foo/bar:Q4",
+		"choices": [{
+			"index": 0,
+			"message": {"role": "assistant", "content": "Hello world"},
+			"finish_reason": "stop"
+		}],
+		"usage": {"prompt_tokens": 12, "completion_tokens": 3, "total_tokens": 15}
+	}`
+
+	out, err := translateOpenAIResponse([]byte(openAI), "msg_abc")
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+
+	var got anthropicMessagesResponse
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ID != "msg_abc" {
+		t.Errorf("id = %q, want msg_abc", got.ID)
+	}
+	if got.Type != "message" || got.Role != "assistant" {
+		t.Errorf("type/role = %q/%q", got.Type, got.Role)
+	}
+	if got.StopReason != "end_turn" {
+		t.Errorf("stop_reason = %q, want end_turn", got.StopReason)
+	}
+	if len(got.Content) != 1 || got.Content[0].Text != "Hello world" {
+		t.Errorf("content = %+v", got.Content)
+	}
+	if got.Usage.InputTokens != 12 || got.Usage.OutputTokens != 3 {
+		t.Errorf("usage = %+v", got.Usage)
+	}
+}
+
+func TestMapFinishReason(t *testing.T) {
+	cases := map[string]string{
+		"stop":           "end_turn",
+		"length":         "max_tokens",
+		"tool_calls":     "tool_use",
+		"function_call":  "tool_use",
+		"content_filter": "end_turn",
+		"":               "",
+		"unexpected":     "end_turn",
+	}
+	for in, want := range cases {
+		if got := mapFinishReason(in); got != want {
+			t.Errorf("mapFinishReason(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestTranslateAnthropicStream_HappyPath(t *testing.T) {
+	// Two deltas, then a finish chunk with usage.
+	upstream := strings.Join([]string{
+		`data: {"id":"c","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}`,
+		`data: {"id":"c","model":"m","choices":[{"index":0,"delta":{"content":"Hel"}}]}`,
+		`data: {"id":"c","model":"m","choices":[{"index":0,"delta":{"content":"lo"}}]}`,
+		`data: {"id":"c","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(upstream), "msg_1", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	got := buf.String()
+	wantEvents := []string{
+		"event: message_start",
+		"event: content_block_start",
+		"event: content_block_delta",
+		`"text":"Hel"`,
+		`"text":"lo"`,
+		"event: content_block_stop",
+		"event: message_delta",
+		`"stop_reason":"end_turn"`,
+		`"input_tokens":5`,
+		`"output_tokens":2`,
+		"event: message_stop",
+	}
+	for _, w := range wantEvents {
+		if !strings.Contains(got, w) {
+			t.Errorf("stream output missing %q\n--- output ---\n%s", w, got)
+		}
+	}
+
+	// message_start must precede any content_block_delta.
+	startIdx := strings.Index(got, "message_start")
+	deltaIdx := strings.Index(got, "content_block_delta")
+	if startIdx < 0 || deltaIdx < 0 || startIdx > deltaIdx {
+		t.Errorf("message_start must come before content_block_delta (start=%d, delta=%d)", startIdx, deltaIdx)
+	}
+}
+
+func TestTranslateAnthropicStream_EmptyUpstreamStillEmitsFrame(t *testing.T) {
+	// Backend closed without sending anything — we must still emit a valid
+	// Anthropic frame so the client doesn't hang.
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(""), "msg_x", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	got := buf.String()
+	for _, ev := range []string{"message_start", "content_block_stop", "message_delta", "message_stop"} {
+		if !strings.Contains(got, "event: "+ev) {
+			t.Errorf("missing %q in output:\n%s", ev, got)
+		}
+	}
+}
+
+func TestTranslateAnthropicStream_MappedFinishReason(t *testing.T) {
+	upstream := strings.Join([]string{
+		`data: {"id":"c","model":"m","choices":[{"index":0,"delta":{"content":"x"},"finish_reason":"length"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+	var buf bytes.Buffer
+	if err := translateAnthropicStream(&buf, strings.NewReader(upstream), "msg", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"stop_reason":"max_tokens"`) {
+		t.Errorf("expected max_tokens stop_reason, got:\n%s", buf.String())
+	}
+}
+
+func TestCountAnthropicTokens(t *testing.T) {
+	// A 7-char string should yield ceil(7/3.5) = 2 tokens.
+	body := []byte(`{
+		"model": "m",
+		"messages": [{"role": "user", "content": "abcdefg"}]
+	}`)
+	n, err := countAnthropicTokens(body)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("count = %d, want 2", n)
+	}
+}
+
+func TestCountAnthropicTokens_IncludesSystemAndBlocks(t *testing.T) {
+	body := []byte(`{
+		"model": "m",
+		"system": "abcdefg",
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "hijklmn"},
+				{"type": "text", "text": "opqrstu"}
+			]
+		}]
+	}`)
+	// 3 segments × 7 chars → ceil(7/3.5)=2 tokens each → 6 total.
+	n, err := countAnthropicTokens(body)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 6 {
+		t.Errorf("count = %d, want 6", n)
+	}
+}

--- a/internal/proxy/anthropic_test.go
+++ b/internal/proxy/anthropic_test.go
@@ -798,10 +798,10 @@ func TestTranslateAnthropicRequest_ThinkingBlockRejected(t *testing.T) {
 	}
 }
 
-// Vision URL sources aren't yet supported (only base64). Ensure clients
-// passing {type:"url", url:"..."} get a clear error rather than silent
-// malformation.
-func TestTranslateAnthropicRequest_ImageURLSourceRejected(t *testing.T) {
+// Anthropic supports `source.type: "url"` for images (added 2024); llama.cpp
+// passes the URL through verbatim. We do the same — no download, no
+// validation; let the backend fetch.
+func TestTranslateAnthropicRequest_ImageURLSourcePassthrough(t *testing.T) {
 	in := []byte(`{
 		"model": "m",
 		"max_tokens": 5,
@@ -812,13 +812,38 @@ func TestTranslateAnthropicRequest_ImageURLSourceRejected(t *testing.T) {
 			]
 		}]
 	}`)
+	out, _, err := translateAnthropicRequest(in)
+	if err != nil {
+		t.Fatalf("url image should be accepted, got: %v", err)
+	}
+	var got openAIChatRequest
+	_ = json.Unmarshal(out, &got)
+	var parts []openAIContentPart
+	_ = json.Unmarshal(got.Messages[0].Content, &parts)
+	if len(parts) != 1 || parts[0].ImageURL == nil {
+		t.Fatalf("expected one image_url part; got %+v", parts)
+	}
+	if parts[0].ImageURL.URL != "https://example.com/x.png" {
+		t.Errorf("image url = %q, want passthrough", parts[0].ImageURL.URL)
+	}
+}
+
+// A url-source block without a url should still produce a clear 400.
+func TestTranslateAnthropicRequest_ImageURLSourceMissingURL(t *testing.T) {
+	in := []byte(`{
+		"model": "m",
+		"max_tokens": 5,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "image", "source": {"type": "url"}}
+			]
+		}]
+	}`)
 	_, _, err := translateAnthropicRequest(in)
 	var te *translateError
 	if !errors.As(err, &te) || te.status != 400 {
 		t.Fatalf("got err %v, want 400", err)
-	}
-	if !strings.Contains(te.msg, "base64") {
-		t.Errorf("error message should mention base64: %q", te.msg)
 	}
 }
 

--- a/internal/proxy/anthropic_test.go
+++ b/internal/proxy/anthropic_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestTranslateAnthropicRequest_StringContent(t *testing.T) {
@@ -968,13 +971,98 @@ func TestTranslateAnthropicStream_MessageStartUsageZero(t *testing.T) {
 	if payload.Message.Usage.InputTokens == nil {
 		t.Fatal("message_start.usage.input_tokens missing; spec requires the key present")
 	}
+	if payload.Message.Usage.OutputTokens == nil {
+		t.Fatal("message_start.usage.output_tokens missing; spec requires the key present")
+	}
 	// Currently 0 by design (see package-level known limitations). If a
-	// buffering strategy lands, this assertion is the signal to update the
-	// docs and the test together — it's the whole point of the lock-in.
+	// buffering strategy lands, these assertions are the signal to update
+	// the docs and the tests together — it's the whole point of the lock-in.
 	if *payload.Message.Usage.InputTokens != 0 {
 		t.Errorf("message_start.usage.input_tokens = %d; documented as 0 — update docs + this test if buffering intentionally landed",
 			*payload.Message.Usage.InputTokens)
 	}
+	if *payload.Message.Usage.OutputTokens != 0 {
+		t.Errorf("message_start.usage.output_tokens = %d; documented as 0 at open-of-stream",
+			*payload.Message.Usage.OutputTokens)
+	}
+}
+
+// With a very short ping interval and a slow upstream, we must see at
+// least one `event: ping` between content_block_delta frames. Tests the
+// nginx-idle-kill mitigation: without pings a 60s+ inter-token gap would
+// break the stream at the middleware layer.
+func TestTranslateAnthropicStream_PingsWhileIdle(t *testing.T) {
+	orig := streamPingInterval
+	streamPingInterval = 10 * time.Millisecond
+	defer func() { streamPingInterval = orig }()
+
+	// slowReader drip-feeds two content deltas with a 100ms gap between
+	// them. The ping ticker (10ms) should fire several times during the
+	// gap.
+	upstream := &slowReader{
+		chunks: []string{
+			"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"a\"}}]}\n\n",
+			"data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"b\"}}]}\n\n",
+			"data: [DONE]\n\n",
+		},
+		gap: 100 * time.Millisecond,
+	}
+	var buf safeBuffer
+	if err := translateAnthropicStream(&buf, upstream, "msg", "m"); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	events := decodeSSE(t, buf.String())
+	var pings int
+	for _, ev := range events {
+		if ev.name == "ping" {
+			pings++
+		}
+	}
+	if pings == 0 {
+		t.Errorf("no ping events emitted over %d-chunk slow stream:\n%s", len(upstream.chunks), buf.String())
+	}
+}
+
+// safeBuffer synchronizes writes so the translator's concurrent ping
+// goroutine and main loop don't race on a bytes.Buffer.
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// slowReader emits one chunk per Read call, sleeping `gap` between chunks
+// so the translator's ping ticker has time to fire. Unlike a bytes.Reader
+// that empties synchronously, this keeps the stream "live" long enough to
+// exercise the idle-ping path.
+type slowReader struct {
+	chunks []string
+	gap    time.Duration
+	i      int
+}
+
+func (r *slowReader) Read(p []byte) (int, error) {
+	if r.i >= len(r.chunks) {
+		return 0, io.EOF
+	}
+	if r.i > 0 {
+		time.Sleep(r.gap)
+	}
+	n := copy(p, r.chunks[r.i])
+	r.i++
+	return n, nil
 }
 
 // An upstream chunk that carries both `content` and `finish_reason` on the

--- a/internal/proxy/backend.go
+++ b/internal/proxy/backend.go
@@ -1,0 +1,46 @@
+package proxy
+
+// A Runtime implements the backend-specific parts of process lifecycle:
+// which binary to run, how to build its CLI args, how to check readiness,
+// and how to recognize fatal startup errors from its logs. ModelManager
+// owns the generic parts (ports, logs, LRU, idle eviction, signal
+// handling) and delegates the rest through this interface so llama-server
+// and future backends (SwiftLM/MLX) can coexist.
+type Runtime interface {
+	Kind() BackendKind
+
+	// BinaryPath returns the absolute path to the executable.
+	BinaryPath() string
+
+	// WorkingDir returns the directory to set as the process cwd. Some
+	// backends locate sidecar files (templates, metallib) relative to the
+	// binary and need a specific cwd.
+	WorkingDir() string
+
+	// BuildArgs returns the CLI arguments for starting this backend's
+	// server against the given backend instance. host is the address the
+	// backend should bind to; the port comes from backend.Port.
+	BuildArgs(backend *Backend, host string) []string
+
+	// HealthURL returns the URL the proxy polls to determine readiness.
+	HealthURL(host string, port int) string
+
+	// IsStartupError inspects the backend's log file and returns true when
+	// a fatal error indicates the process will not become ready.
+	IsStartupError(logPath string) bool
+}
+
+// BackendKind identifies a backend implementation.
+type BackendKind string
+
+const (
+	BackendKindLlama BackendKind = "llama"
+	BackendKindMLX   BackendKind = "mlx"
+)
+
+// selectRuntime chooses the Runtime for a given model. Today this is always
+// llama-server; once metadata.yaml records a per-model backend type, this
+// will read it and branch on the recorded kind.
+func (m *ModelManager) selectRuntime(modelPath, modelName string) Runtime {
+	return NewLlamaRuntime(m.appConfig)
+}

--- a/internal/proxy/backend.go
+++ b/internal/proxy/backend.go
@@ -9,6 +9,13 @@ package proxy
 type Runtime interface {
 	Kind() BackendKind
 
+	// HFAppName returns the HuggingFace "apps=" filter value that lists
+	// models this backend can load (e.g. "llama.cpp" for GGUF,
+	// "mlx-lm" for MLX). The search/trending UI joins the names of all
+	// registered runtimes into one filter so adding a backend doesn't
+	// require editing the discovery surface.
+	HFAppName() string
+
 	// BinaryPath returns the absolute path to the executable.
 	BinaryPath() string
 

--- a/internal/proxy/backend.go
+++ b/internal/proxy/backend.go
@@ -35,6 +35,12 @@ type Runtime interface {
 	// IsStartupError inspects the backend's log file and returns true when
 	// a fatal error indicates the process will not become ready.
 	IsStartupError(logPath string) bool
+
+	// SignificantOptions returns the option keys whose value changes require
+	// stopping and restarting the backend (rather than being harmlessly
+	// ignored or applied per-request). The manager uses this to decide
+	// whether a /api/run call with new options should reload the model.
+	SignificantOptions() []string
 }
 
 // BackendKind identifies a backend implementation.

--- a/internal/proxy/backend.go
+++ b/internal/proxy/backend.go
@@ -37,10 +37,3 @@ const (
 	BackendKindLlama BackendKind = "llama"
 	BackendKindMLX   BackendKind = "mlx"
 )
-
-// selectRuntime chooses the Runtime for a given model. Today this is always
-// llama-server; once metadata.yaml records a per-model backend type, this
-// will read it and branch on the recorded kind.
-func (m *ModelManager) selectRuntime(modelPath, modelName string) Runtime {
-	return NewLlamaRuntime(m.appConfig)
-}

--- a/internal/proxy/backend_llama.go
+++ b/internal/proxy/backend_llama.go
@@ -70,6 +70,23 @@ func (r *LlamaRuntime) IsStartupError(logPath string) bool {
 	return hasStartupError(logPath)
 }
 
+// SignificantOptions returns llama-server flags that change model-load
+// behavior. Sampling knobs (temp, top-p, ...) are overridable per-request
+// and stay off the list — changing them shouldn't force a reload.
+func (r *LlamaRuntime) SignificantOptions() []string {
+	return []string{
+		"ctx-size",
+		"gpu-layers",
+		"threads",
+		"batch-size",
+		"ubatch-size",
+		"flash-attn",
+		"mlock",
+		"cache-type-k",
+		"cache-type-v",
+	}
+}
+
 // findMMProjForModel parses the model name and checks if an mmproj file exists.
 // ModelName format: "user/repo:quant" (e.g., "ggml-org/gemma-3-4b-it-GGUF:Q4_K_M")
 func findMMProjForModel(modelName string) string {

--- a/internal/proxy/backend_llama.go
+++ b/internal/proxy/backend_llama.go
@@ -25,6 +25,8 @@ func NewLlamaRuntime(appConfig *config.Config) *LlamaRuntime {
 
 func (r *LlamaRuntime) Kind() BackendKind { return BackendKindLlama }
 
+func (r *LlamaRuntime) HFAppName() string { return "llama.cpp" }
+
 func (r *LlamaRuntime) BinaryPath() string { return llama.ServerPath() }
 
 func (r *LlamaRuntime) WorkingDir() string { return config.BinPath() }

--- a/internal/proxy/backend_llama.go
+++ b/internal/proxy/backend_llama.go
@@ -1,0 +1,146 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"maps"
+	"os"
+	"strings"
+
+	"github.com/nchapman/lleme/internal/config"
+	"github.com/nchapman/lleme/internal/hf"
+	"github.com/nchapman/lleme/internal/llama"
+)
+
+// LlamaRuntime implements Runtime for llama.cpp's llama-server.
+type LlamaRuntime struct {
+	appConfig *config.Config
+}
+
+// NewLlamaRuntime constructs a llama-server runtime. appConfig supplies the
+// LlamaCpp.Options map that's merged into per-backend options at start time.
+func NewLlamaRuntime(appConfig *config.Config) *LlamaRuntime {
+	return &LlamaRuntime{appConfig: appConfig}
+}
+
+func (r *LlamaRuntime) Kind() BackendKind { return BackendKindLlama }
+
+func (r *LlamaRuntime) BinaryPath() string { return llama.ServerPath() }
+
+func (r *LlamaRuntime) WorkingDir() string { return config.BinPath() }
+
+func (r *LlamaRuntime) HealthURL(host string, port int) string {
+	return fmt.Sprintf("http://%s:%d/health", host, port)
+}
+
+func (r *LlamaRuntime) BuildArgs(backend *Backend, host string) []string {
+	args := []string{
+		"--model", backend.ModelPath,
+		"--host", host,
+		"--port", fmt.Sprintf("%d", backend.Port),
+		"--embeddings", // Enable /v1/embeddings endpoint
+		"--no-webui",   // Disable built-in web UI (lleme is a proxy)
+	}
+
+	// Check for mmproj file (vision model support)
+	if mmprojPath := findMMProjForModel(backend.ModelName); mmprojPath != "" {
+		args = append(args, "--mmproj", mmprojPath)
+	}
+
+	// Apply template patches to work around llama-server issues.
+	// See template.go for the patch registry and documentation.
+	if templatePath, err := ExtractAndPatchTemplate(backend.ModelPath); err == nil && templatePath != "" {
+		args = append(args, "--chat-template-file", templatePath)
+	}
+
+	// Merge config options with backend-specific options (backend overrides config)
+	mergedOptions := make(map[string]any)
+	if r.appConfig != nil {
+		maps.Copy(mergedOptions, r.appConfig.LlamaCpp.Options)
+	}
+	maps.Copy(mergedOptions, backend.Options)
+
+	args = append(args, buildLlamaServerArgs(mergedOptions)...)
+	return args
+}
+
+func (r *LlamaRuntime) IsStartupError(logPath string) bool {
+	return hasStartupError(logPath)
+}
+
+// findMMProjForModel parses the model name and checks if an mmproj file exists.
+// ModelName format: "user/repo:quant" (e.g., "ggml-org/gemma-3-4b-it-GGUF:Q4_K_M")
+func findMMProjForModel(modelName string) string {
+	parts := strings.Split(modelName, ":")
+	if len(parts) != 2 {
+		return ""
+	}
+
+	repoRef := parts[0]
+	quant := parts[1]
+
+	repoParts := strings.Split(repoRef, "/")
+	if len(repoParts) != 2 {
+		return ""
+	}
+
+	user := repoParts[0]
+	repo := repoParts[1]
+
+	return hf.FindMMProjFile(user, repo, quant)
+}
+
+// buildLlamaServerArgs converts the llama_server config map to command-line arguments.
+func buildLlamaServerArgs(config map[string]any) []string {
+	if config == nil {
+		return nil
+	}
+
+	var args []string
+	for key, value := range config {
+		flag := "--" + key
+
+		switch v := value.(type) {
+		case bool:
+			if v {
+				args = append(args, flag)
+			}
+			// false booleans are omitted (use default)
+		case int:
+			args = append(args, flag, fmt.Sprintf("%d", v))
+		case float64:
+			// YAML parses numbers as float64, check if it's a whole number
+			if v == float64(int(v)) {
+				args = append(args, flag, fmt.Sprintf("%d", int(v)))
+			} else {
+				args = append(args, flag, fmt.Sprintf("%g", v))
+			}
+		case string:
+			if v != "" {
+				args = append(args, flag, v)
+			}
+		}
+	}
+
+	return args
+}
+
+func hasStartupError(logFile string) bool {
+	file, err := os.Open(logFile)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.ToLower(scanner.Text())
+		if strings.Contains(line, "error") && strings.Contains(line, "failed") {
+			return true
+		}
+		if strings.Contains(line, "could not load model") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/proxy/backend_select.go
+++ b/internal/proxy/backend_select.go
@@ -9,10 +9,8 @@ import (
 // selectRuntime resolves a Runtime for the given model based on the backend
 // kind recorded in metadata.yaml at pull time. Legacy metadata without a
 // backend field is treated as "gguf" so existing installs keep working.
-//
-// Returns an error when the recorded kind has no implementation yet (e.g.
-// MLX before the SwiftLM runtime lands) so callers surface a clear message
-// instead of silently launching the wrong backend.
+// Unknown kinds surface as errors from hf.GetBackendKind so a corrupt or
+// tampered metadata file can't silently dispatch to the wrong runtime.
 func (m *ModelManager) selectRuntime(user, repo, quant string) (Runtime, error) {
 	kind, err := hf.GetBackendKind(user, repo, quant)
 	if err != nil {
@@ -24,6 +22,10 @@ func (m *ModelManager) selectRuntime(user, repo, quant string) (Runtime, error) 
 	case hf.BackendMLX:
 		return NewSwiftLMRuntime(m.appConfig), nil
 	default:
-		return nil, fmt.Errorf("unknown backend kind %q for %s/%s:%s", kind, user, repo, quant)
+		// Unreachable today: GetBackendKind already rejected anything that
+		// isn't BackendGGUF / BackendMLX. Kept as a belt-and-suspenders
+		// default so adding a new kind to hf without wiring it here still
+		// fails closed.
+		return nil, fmt.Errorf("no runtime registered for backend kind %q", kind)
 	}
 }

--- a/internal/proxy/backend_select.go
+++ b/internal/proxy/backend_select.go
@@ -1,0 +1,29 @@
+package proxy
+
+import (
+	"fmt"
+
+	"github.com/nchapman/lleme/internal/hf"
+)
+
+// selectRuntime resolves a Runtime for the given model based on the backend
+// kind recorded in metadata.yaml at pull time. Legacy metadata without a
+// backend field is treated as "gguf" so existing installs keep working.
+//
+// Returns an error when the recorded kind has no implementation yet (e.g.
+// MLX before the SwiftLM runtime lands) so callers surface a clear message
+// instead of silently launching the wrong backend.
+func (m *ModelManager) selectRuntime(user, repo, quant string) (Runtime, error) {
+	kind, err := hf.GetBackendKind(user, repo, quant)
+	if err != nil {
+		return nil, fmt.Errorf("reading backend metadata for %s/%s:%s: %w", user, repo, quant, err)
+	}
+	switch kind {
+	case hf.BackendGGUF:
+		return NewLlamaRuntime(m.appConfig), nil
+	case hf.BackendMLX:
+		return nil, fmt.Errorf("MLX backend not yet implemented (model %s/%s:%s)", user, repo, quant)
+	default:
+		return nil, fmt.Errorf("unknown backend kind %q for %s/%s:%s", kind, user, repo, quant)
+	}
+}

--- a/internal/proxy/backend_select.go
+++ b/internal/proxy/backend_select.go
@@ -22,7 +22,7 @@ func (m *ModelManager) selectRuntime(user, repo, quant string) (Runtime, error) 
 	case hf.BackendGGUF:
 		return NewLlamaRuntime(m.appConfig), nil
 	case hf.BackendMLX:
-		return nil, fmt.Errorf("MLX backend not yet implemented (model %s/%s:%s)", user, repo, quant)
+		return NewSwiftLMRuntime(m.appConfig), nil
 	default:
 		return nil, fmt.Errorf("unknown backend kind %q for %s/%s:%s", kind, user, repo, quant)
 	}

--- a/internal/proxy/backend_select_test.go
+++ b/internal/proxy/backend_select_test.go
@@ -1,0 +1,63 @@
+package proxy
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/nchapman/lleme/internal/hf"
+)
+
+func TestSelectRuntime(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", oldHome)
+	os.Setenv("HOME", tmpDir)
+
+	user, repo := "u", "r"
+	if err := os.MkdirAll(hf.GetModelPath(user, repo), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	m := NewModelManager(DefaultConfig(), nil)
+
+	tests := []struct {
+		name    string
+		quant   string
+		kind    string
+		wantErr string
+	}{
+		{"legacy empty defaults to gguf", "q_legacy", "", ""},
+		{"gguf returns llama runtime", "q_gguf", hf.BackendGGUF, ""},
+		{"mlx not yet implemented", "q_mlx", hf.BackendMLX, "MLX backend not yet implemented"},
+		{"unknown kind errors", "q_bogus", "bogus", "unknown backend kind"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			quant := tt.quant
+			if tt.kind != "" {
+				if err := hf.SetBackendKind(user, repo, quant, tt.kind); err != nil {
+					t.Fatalf("SetBackendKind: %v", err)
+				}
+			}
+
+			rt, err := m.selectRuntime(user, repo, quant)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("selectRuntime: %v", err)
+				}
+				if rt.Kind() != BackendKindLlama {
+					t.Errorf("kind = %v, want llama", rt.Kind())
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("err = %v, want containing %q", err, tt.wantErr)
+			}
+			if rt != nil {
+				t.Error("expected nil runtime on error")
+			}
+		})
+	}
+}

--- a/internal/proxy/backend_select_test.go
+++ b/internal/proxy/backend_select_test.go
@@ -22,15 +22,16 @@ func TestSelectRuntime(t *testing.T) {
 	m := NewModelManager(DefaultConfig(), nil)
 
 	tests := []struct {
-		name    string
-		quant   string
-		kind    string
-		wantErr string
+		name     string
+		quant    string
+		kind     string
+		wantErr  string
+		wantKind BackendKind
 	}{
-		{"legacy empty defaults to gguf", "q_legacy", "", ""},
-		{"gguf returns llama runtime", "q_gguf", hf.BackendGGUF, ""},
-		{"mlx not yet implemented", "q_mlx", hf.BackendMLX, "MLX backend not yet implemented"},
-		{"unknown kind errors", "q_bogus", "bogus", "unknown backend kind"},
+		{"legacy empty defaults to gguf", "q_legacy", "", "", BackendKindLlama},
+		{"gguf returns llama runtime", "q_gguf", hf.BackendGGUF, "", BackendKindLlama},
+		{"mlx returns swiftlm runtime", "q_mlx", hf.BackendMLX, "", BackendKindMLX},
+		{"unknown kind errors", "q_bogus", "bogus", "unknown backend kind", ""},
 	}
 
 	for _, tt := range tests {
@@ -47,8 +48,8 @@ func TestSelectRuntime(t *testing.T) {
 				if err != nil {
 					t.Fatalf("selectRuntime: %v", err)
 				}
-				if rt.Kind() != BackendKindLlama {
-					t.Errorf("kind = %v, want llama", rt.Kind())
+				if rt.Kind() != tt.wantKind {
+					t.Errorf("kind = %v, want %v", rt.Kind(), tt.wantKind)
 				}
 				return
 			}

--- a/internal/proxy/backend_select_test.go
+++ b/internal/proxy/backend_select_test.go
@@ -31,7 +31,7 @@ func TestSelectRuntime(t *testing.T) {
 		{"legacy empty defaults to gguf", "q_legacy", "", "", BackendKindLlama},
 		{"gguf returns llama runtime", "q_gguf", hf.BackendGGUF, "", BackendKindLlama},
 		{"mlx returns swiftlm runtime", "q_mlx", hf.BackendMLX, "", BackendKindMLX},
-		{"unknown kind errors", "q_bogus", "bogus", "unknown backend kind", ""},
+		{"unknown kind errors", "q_bogus", "bogus", "unrecognized backend kind", ""},
 	}
 
 	for _, tt := range tests {

--- a/internal/proxy/backend_swiftlm.go
+++ b/internal/proxy/backend_swiftlm.go
@@ -28,6 +28,8 @@ func NewSwiftLMRuntime(appConfig *config.Config) *SwiftLMRuntime {
 
 func (r *SwiftLMRuntime) Kind() BackendKind { return BackendKindMLX }
 
+func (r *SwiftLMRuntime) HFAppName() string { return "mlx-lm" }
+
 func (r *SwiftLMRuntime) BinaryPath() string { return swiftlm.ServerPath() }
 
 // WorkingDir points at the versioned SwiftLM directory so the binary finds

--- a/internal/proxy/backend_swiftlm.go
+++ b/internal/proxy/backend_swiftlm.go
@@ -1,0 +1,204 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nchapman/lleme/internal/config"
+	"github.com/nchapman/lleme/internal/swiftlm"
+)
+
+// SwiftLMRuntime implements Runtime for SharpAI/SwiftLM — the Apple-Silicon
+// MLX server. Its CLI surface is much narrower than llama-server's, so we
+// translate a known set of keys and silently drop the rest rather than pass
+// everything through like the llama runtime does. Until Commit 7's per-
+// backend FilterSamplingKeys lands, this local allow-list is the guard that
+// keeps llama-specific keys from reaching SwiftLM as invalid flags.
+type SwiftLMRuntime struct {
+	appConfig *config.Config
+}
+
+func NewSwiftLMRuntime(appConfig *config.Config) *SwiftLMRuntime {
+	return &SwiftLMRuntime{appConfig: appConfig}
+}
+
+func (r *SwiftLMRuntime) Kind() BackendKind { return BackendKindMLX }
+
+func (r *SwiftLMRuntime) BinaryPath() string { return swiftlm.ServerPath() }
+
+// WorkingDir points at the versioned SwiftLM directory so the binary finds
+// its sibling mlx.metallib at runtime.
+func (r *SwiftLMRuntime) WorkingDir() string {
+	return filepath.Dir(swiftlm.ServerPath())
+}
+
+func (r *SwiftLMRuntime) HealthURL(host string, port int) string {
+	return fmt.Sprintf("http://%s:%d/health", host, port)
+}
+
+// swiftlmValueFlags maps an option key to the CLI flag SwiftLM expects.
+// Keys are the snake_case / kebab-case forms our options pipeline produces
+// (CLI flags → config → preset → persona → request body); values are
+// SwiftLM's own flag names, confirmed against `SwiftLM --help` on b517.
+//
+// Anything not on this list is dropped — SwiftLM rejects unknown flags at
+// startup with a bare `Error:` line, so silently ignoring llama-only keys
+// (mirostat, xtc_*, dry_*, frequency_penalty, grammar, ...) is strictly
+// safer than forwarding them.
+var swiftlmValueFlags = map[string]string{
+	// Core
+	"ctx_size":     "--ctx-size",
+	"ctx-size":     "--ctx-size",
+	"max_tokens":   "--max-tokens",
+	"max-tokens":   "--max-tokens",
+	"parallel":     "--parallel",
+	"gpu_layers":   "--gpu-layers",
+	"gpu-layers":   "--gpu-layers",
+	"mem_limit":    "--mem-limit",
+	"mem-limit":    "--mem-limit",
+	"prefill":      "--prefill-size",
+	"prefill_size": "--prefill-size",
+	"prefill-size": "--prefill-size",
+	"api_key":      "--api-key",
+	"api-key":      "--api-key",
+	"cors":         "--cors",
+	// Sampling
+	"temp":               "--temp",
+	"temperature":        "--temp",
+	"top_p":              "--top-p",
+	"top-p":              "--top-p",
+	"top_k":              "--top-k",
+	"top-k":              "--top-k",
+	"min_p":              "--min-p",
+	"min-p":              "--min-p",
+	"repeat_penalty":     "--repeat-penalty",
+	"repeat-penalty":     "--repeat-penalty",
+	"repetition_penalty": "--repeat-penalty",
+	// Speculative decoding
+	"draft_model":      "--draft-model",
+	"draft-model":      "--draft-model",
+	"num_draft_tokens": "--num-draft-tokens",
+	"num-draft-tokens": "--num-draft-tokens",
+}
+
+// swiftlmBoolFlags are SwiftLM's boolean switches. A truthy value emits the
+// flag; a falsy value omits it.
+var swiftlmBoolFlags = map[string]string{
+	"thinking":       "--thinking",
+	"vision":         "--vision",
+	"audio":          "--audio",
+	"stream_experts": "--stream-experts",
+	"stream-experts": "--stream-experts",
+	"turbo_kv":       "--turbo-kv",
+	"turbo-kv":       "--turbo-kv",
+	"ssd_prefetch":   "--ssd-prefetch",
+	"ssd-prefetch":   "--ssd-prefetch",
+	"calibrate":      "--calibrate",
+}
+
+func (r *SwiftLMRuntime) BuildArgs(backend *Backend, host string) []string {
+	args := []string{
+		"--model", backend.ModelPath,
+		"--host", host,
+		"--port", fmt.Sprintf("%d", backend.Port),
+	}
+
+	// Merge config defaults with per-request options (request wins). Config
+	// lives under a SwiftLM-specific key so llama-server options don't bleed
+	// in; the key is optional, so missing config is fine.
+	merged := make(map[string]any)
+	if r.appConfig != nil {
+		maps.Copy(merged, r.appConfig.SwiftLM.Options)
+	}
+	maps.Copy(merged, backend.Options)
+
+	args = append(args, mapSwiftLMOptions(merged)...)
+	return args
+}
+
+// mapSwiftLMOptions turns an option map into SwiftLM CLI args, dropping any
+// key that isn't on the allow-list. Value handling mirrors the llama
+// runtime: int/float/string formatted verbatim, bool emits the flag if true.
+func mapSwiftLMOptions(opts map[string]any) []string {
+	var args []string
+	for key, value := range opts {
+		if flag, ok := swiftlmBoolFlags[key]; ok {
+			if isTruthy(value) {
+				args = append(args, flag)
+			}
+			continue
+		}
+		flag, ok := swiftlmValueFlags[key]
+		if !ok {
+			continue // silently drop unsupported keys
+		}
+		switch v := value.(type) {
+		case int:
+			args = append(args, flag, fmt.Sprintf("%d", v))
+		case float64:
+			if v == float64(int(v)) {
+				args = append(args, flag, fmt.Sprintf("%d", int(v)))
+			} else {
+				args = append(args, flag, fmt.Sprintf("%g", v))
+			}
+		case string:
+			if v != "" {
+				args = append(args, flag, v)
+			}
+		}
+	}
+	return args
+}
+
+// isTruthy accepts the common boolean representations YAML/JSON produce.
+// Strict bool-only matching would silently drop `thinking: 1` or
+// `vision: "true"` — surprising for users who've copy-pasted from other
+// configs or request bodies.
+func isTruthy(v any) bool {
+	switch val := v.(type) {
+	case bool:
+		return val
+	case int:
+		return val != 0
+	case float64:
+		return val != 0
+	case string:
+		switch val {
+		case "true", "True", "TRUE", "1", "yes", "on":
+			return true
+		}
+	}
+	return false
+}
+
+// IsStartupError scans the backend log for SwiftLM's error marker. The
+// binary prints a plain `Error: ...` line (no prefix) when arg parsing or
+// model loading fails, and keeps running otherwise. We only treat an Error
+// line as fatal if it appears before any serving-ready marker — SwiftLM
+// prints `[SwiftLM]` progress lines during model load that we don't want to
+// misread. Today any Error: line is fatal (server exits), so the simple
+// scan is correct; revisit if SwiftLM grows non-fatal Error: logs.
+func (r *SwiftLMRuntime) IsStartupError(logPath string) bool {
+	file, err := os.Open(logPath)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	// Default buffer caps at 64 KiB; a long path embedded in an Error: line
+	// would otherwise silently truncate and we'd miss a fatal. 256 KiB is
+	// well above anything realistic.
+	scanner.Buffer(make([]byte, 64*1024), 256*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "Error:") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/proxy/backend_swiftlm.go
+++ b/internal/proxy/backend_swiftlm.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/nchapman/lleme/internal/config"
+	"github.com/nchapman/lleme/internal/logs"
 	"github.com/nchapman/lleme/internal/swiftlm"
 )
 
@@ -151,7 +152,12 @@ func mapSwiftLMOptions(opts map[string]any) []string {
 		}
 		flag, ok := swiftlmValueFlags[key]
 		if !ok {
-			continue // silently drop unsupported keys
+			// Log at debug so typos in swiftlm.options leave a trail
+			// without polluting default output — users legitimately share
+			// options between backends via preset/persona, so most drops
+			// are intentional.
+			logs.Debug("dropping unsupported SwiftLM option", "key", rawKey)
+			continue
 		}
 		switch v := value.(type) {
 		case int:
@@ -192,13 +198,52 @@ func isTruthy(v any) bool {
 	return false
 }
 
-// IsStartupError scans the backend log for SwiftLM's error marker. The
-// binary prints a plain `Error: ...` line (no prefix) when arg parsing or
-// model loading fails, and keeps running otherwise. We only treat an Error
-// line as fatal if it appears before any serving-ready marker — SwiftLM
-// prints `[SwiftLM]` progress lines during model load that we don't want to
-// misread. Today any Error: line is fatal (server exits), so the simple
-// scan is correct; revisit if SwiftLM grows non-fatal Error: logs.
+// swiftLMStartupErrorMarkers lists the shapes SwiftLM emits when it fails
+// to come up. The binary is a Swift ArgumentParser app, so it prints a
+// plain `Error: …` for arg-validation failures. Runtime failures — OOM via
+// fatalError, a forced-try on missing weights, a bad model path — surface
+// as `Fatal error:` lines (sometimes prefixed with `Swift/<file>:…` stacks
+// or `Thread 1:`). Missing metallib or dylib dependencies abort via dyld
+// before any model code runs, producing `dyld[...]: ... Library not
+// loaded` on stderr.
+//
+// Ordering is significant only for marker documentation; lineIndicatesStartupError
+// returns on first match. `substr` markers use strings.Contains so they catch
+// variants like `Thread 1: Fatal error: ...` and `Swift/ErrorType.swift:XX:
+// Fatal error: 'try!' expression …`.
+type swiftLMMarker struct {
+	kind string // "prefix" or "substr"
+	text string
+}
+
+var swiftLMStartupErrorMarkers = []swiftLMMarker{
+	{kind: "prefix", text: "Error:"},
+	{kind: "prefix", text: "Fatal error:"},
+	{kind: "prefix", text: "fatal error:"},
+	{kind: "substr", text: "Fatal error"}, // covers "Swift/X: Fatal error" and "Thread 1: Fatal error"
+	{kind: "substr", text: "Library not loaded"},
+}
+
+func lineIndicatesStartupError(line string) bool {
+	for _, m := range swiftLMStartupErrorMarkers {
+		switch m.kind {
+		case "prefix":
+			if strings.HasPrefix(line, m.text) {
+				return true
+			}
+		case "substr":
+			if strings.Contains(line, m.text) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsStartupError scans the backend log for any shape SwiftLM uses to
+// signal a startup failure. SwiftLM prints `[SwiftLM]` progress lines
+// during model load which we don't want to misread — every marker above
+// is narrow enough that the progress output can't accidentally match.
 func (r *SwiftLMRuntime) IsStartupError(logPath string) bool {
 	file, err := os.Open(logPath)
 	if err != nil {
@@ -207,13 +252,12 @@ func (r *SwiftLMRuntime) IsStartupError(logPath string) bool {
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
-	// Default buffer caps at 64 KiB; a long path embedded in an Error: line
+	// Default buffer caps at 64 KiB; a long path embedded in an error line
 	// would otherwise silently truncate and we'd miss a fatal. 256 KiB is
 	// well above anything realistic.
 	scanner.Buffer(make([]byte, 64*1024), 256*1024)
 	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "Error:") {
+		if lineIndicatesStartupError(scanner.Text()) {
 			return true
 		}
 	}

--- a/internal/proxy/backend_swiftlm.go
+++ b/internal/proxy/backend_swiftlm.go
@@ -42,62 +42,74 @@ func (r *SwiftLMRuntime) HealthURL(host string, port int) string {
 	return fmt.Sprintf("http://%s:%d/health", host, port)
 }
 
-// swiftlmValueFlags maps an option key to the CLI flag SwiftLM expects.
-// Keys are the snake_case / kebab-case forms our options pipeline produces
-// (CLI flags → config → preset → persona → request body); values are
-// SwiftLM's own flag names, confirmed against `SwiftLM --help` on b517.
+// SignificantOptions returns SwiftLM flags that force a reload when
+// changed. Per-request sampling (temp, top-p, top-k, min-p, repeat-penalty)
+// and max_tokens are overridable on each /v1/chat/completions call and
+// stay off the list. Keys are kebab-case; optionsChanged normalizes inputs
+// so callers can supply either form.
+func (r *SwiftLMRuntime) SignificantOptions() []string {
+	return []string{
+		"ctx-size",
+		"parallel",
+		"gpu-layers",
+		"mem-limit",
+		"prefill-size",
+		"prefill",
+		"thinking",
+		"vision",
+		"audio",
+		"stream-experts",
+		"turbo-kv",
+		"ssd-prefetch",
+		"calibrate",
+		"draft-model",
+		"num-draft-tokens",
+		"api-key",
+	}
+}
+
+// swiftlmValueFlags maps kebab-case option keys to the CLI flag SwiftLM
+// expects. Callers feed mixed casing (snake_case from YAML/JSON, kebab-case
+// from CLI flags); mapSwiftLMOptions normalizes `_` → `-` before lookup so
+// this table stays a single entry per flag. Confirmed against
+// `SwiftLM --help` on b517.
 //
-// Anything not on this list is dropped — SwiftLM rejects unknown flags at
-// startup with a bare `Error:` line, so silently ignoring llama-only keys
-// (mirostat, xtc_*, dry_*, frequency_penalty, grammar, ...) is strictly
-// safer than forwarding them.
+// Anything not on this list (or swiftlmBoolFlags) is dropped — SwiftLM
+// rejects unknown flags at startup with a bare `Error:` line, so silently
+// ignoring llama-only keys (mirostat, xtc-*, dry-*, frequency-penalty,
+// grammar, ...) is strictly safer than forwarding them.
 var swiftlmValueFlags = map[string]string{
 	// Core
-	"ctx_size":     "--ctx-size",
 	"ctx-size":     "--ctx-size",
-	"max_tokens":   "--max-tokens",
 	"max-tokens":   "--max-tokens",
 	"parallel":     "--parallel",
-	"gpu_layers":   "--gpu-layers",
 	"gpu-layers":   "--gpu-layers",
-	"mem_limit":    "--mem-limit",
 	"mem-limit":    "--mem-limit",
 	"prefill":      "--prefill-size",
-	"prefill_size": "--prefill-size",
 	"prefill-size": "--prefill-size",
-	"api_key":      "--api-key",
 	"api-key":      "--api-key",
 	"cors":         "--cors",
 	// Sampling
 	"temp":               "--temp",
 	"temperature":        "--temp",
-	"top_p":              "--top-p",
 	"top-p":              "--top-p",
-	"top_k":              "--top-k",
 	"top-k":              "--top-k",
-	"min_p":              "--min-p",
 	"min-p":              "--min-p",
-	"repeat_penalty":     "--repeat-penalty",
 	"repeat-penalty":     "--repeat-penalty",
-	"repetition_penalty": "--repeat-penalty",
+	"repetition-penalty": "--repeat-penalty",
 	// Speculative decoding
-	"draft_model":      "--draft-model",
 	"draft-model":      "--draft-model",
-	"num_draft_tokens": "--num-draft-tokens",
 	"num-draft-tokens": "--num-draft-tokens",
 }
 
 // swiftlmBoolFlags are SwiftLM's boolean switches. A truthy value emits the
-// flag; a falsy value omits it.
+// flag; a falsy value omits it. Keys are kebab-case (snake_case normalized).
 var swiftlmBoolFlags = map[string]string{
 	"thinking":       "--thinking",
 	"vision":         "--vision",
 	"audio":          "--audio",
-	"stream_experts": "--stream-experts",
 	"stream-experts": "--stream-experts",
-	"turbo_kv":       "--turbo-kv",
 	"turbo-kv":       "--turbo-kv",
-	"ssd_prefetch":   "--ssd-prefetch",
 	"ssd-prefetch":   "--ssd-prefetch",
 	"calibrate":      "--calibrate",
 }
@@ -125,9 +137,12 @@ func (r *SwiftLMRuntime) BuildArgs(backend *Backend, host string) []string {
 // mapSwiftLMOptions turns an option map into SwiftLM CLI args, dropping any
 // key that isn't on the allow-list. Value handling mirrors the llama
 // runtime: int/float/string formatted verbatim, bool emits the flag if true.
+// Keys are normalized snake_case → kebab-case before lookup so the allow-list
+// only needs one entry per flag.
 func mapSwiftLMOptions(opts map[string]any) []string {
 	var args []string
-	for key, value := range opts {
+	for rawKey, value := range opts {
+		key := strings.ReplaceAll(rawKey, "_", "-")
 		if flag, ok := swiftlmBoolFlags[key]; ok {
 			if isTruthy(value) {
 				args = append(args, flag)

--- a/internal/proxy/backend_swiftlm.go
+++ b/internal/proxy/backend_swiftlm.go
@@ -115,6 +115,15 @@ var swiftlmBoolFlags = map[string]string{
 	"calibrate":      "--calibrate",
 }
 
+// TODO(backend-parity): Template patching is currently llama.cpp-only via
+// ExtractAndPatchTemplate (see backend_llama.go). SwiftLM reads
+// chat_template.jinja directly from the MLX repo directory with no CLI
+// override, so we cannot inject a patched template today. MLX variants of
+// models whose Jinja templates trip llama-server's known issues (e.g. the
+// empty tools array handling in proxy/template.go) will produce degraded
+// tool-call output. Revisit when SwiftLM grows a --chat-template-file flag
+// or we ship an inline template-rewriting pass that writes a sibling file
+// SwiftLM picks up before loading.
 func (r *SwiftLMRuntime) BuildArgs(backend *Backend, host string) []string {
 	args := []string{
 		"--model", backend.ModelPath,

--- a/internal/proxy/backend_swiftlm_test.go
+++ b/internal/proxy/backend_swiftlm_test.go
@@ -1,0 +1,139 @@
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/nchapman/lleme/internal/config"
+)
+
+func TestSwiftLMBuildArgsBaseline(t *testing.T) {
+	r := NewSwiftLMRuntime(nil)
+	b := &Backend{ModelName: "u/r:q", ModelPath: "/models/mlx/q4", Port: 12345}
+	args := r.BuildArgs(b, "127.0.0.1")
+
+	want := []string{"--model", "/models/mlx/q4", "--host", "127.0.0.1", "--port", "12345"}
+	if !slices.Equal(args, want) {
+		t.Errorf("args = %v, want %v", args, want)
+	}
+}
+
+func TestSwiftLMBuildArgsMapsKnownOptions(t *testing.T) {
+	r := NewSwiftLMRuntime(nil)
+	b := &Backend{
+		ModelPath: "/m",
+		Port:      5000,
+		Options: map[string]any{
+			"temperature":       0.7,
+			"top_p":             0.95,
+			"top_k":             40,
+			"min_p":             0.05,
+			"repeat_penalty":    1.1,
+			"max_tokens":        1024,
+			"ctx_size":          8192,
+			"vision":            true,
+			"thinking":          false, // falsy → omitted
+			"frequency_penalty": 0.1,   // unknown → dropped
+			"mirostat":          2,     // unknown → dropped
+		},
+	}
+	args := r.BuildArgs(b, "127.0.0.1")
+	argStr := strings.Join(args, " ")
+
+	for _, flag := range []string{"--temp", "--top-p", "--top-k", "--min-p", "--repeat-penalty", "--max-tokens", "--ctx-size", "--vision"} {
+		if !strings.Contains(argStr, flag) {
+			t.Errorf("missing expected flag %q in %v", flag, args)
+		}
+	}
+	for _, flag := range []string{"--frequency-penalty", "--mirostat", "--thinking"} {
+		if strings.Contains(argStr, flag) {
+			t.Errorf("unexpected flag %q in %v", flag, args)
+		}
+	}
+}
+
+func TestSwiftLMBuildArgsRequestOverridesConfig(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.SwiftLM.Options = map[string]any{"temp": 0.5, "top_k": 20}
+
+	r := NewSwiftLMRuntime(cfg)
+	b := &Backend{
+		ModelPath: "/m",
+		Port:      6000,
+		Options:   map[string]any{"temp": 0.9}, // should win
+	}
+	args := r.BuildArgs(b, "127.0.0.1")
+
+	idx := slices.Index(args, "--temp")
+	if idx < 0 || idx+1 >= len(args) || args[idx+1] != "0.9" {
+		t.Errorf("--temp = %v, want 0.9 (request should override config): %v", argAt(args, idx+1), args)
+	}
+	// top_k from config should still appear (not clobbered by the request).
+	if !slices.Contains(args, "--top-k") {
+		t.Errorf("--top-k from config missing: %v", args)
+	}
+}
+
+func TestSwiftLMIsTruthy(t *testing.T) {
+	truthy := []any{true, 1, int(5), float64(1.0), "true", "True", "1", "yes", "on"}
+	falsy := []any{false, 0, float64(0), "", "false", "no", "off", "anything-else", nil}
+	for _, v := range truthy {
+		if !isTruthy(v) {
+			t.Errorf("isTruthy(%v) = false, want true", v)
+		}
+	}
+	for _, v := range falsy {
+		if isTruthy(v) {
+			t.Errorf("isTruthy(%v) = true, want false", v)
+		}
+	}
+}
+
+func argAt(args []string, i int) string {
+	if i < 0 || i >= len(args) {
+		return "<oob>"
+	}
+	return args[i]
+}
+
+func TestSwiftLMIsStartupError(t *testing.T) {
+	tests := []struct {
+		name string
+		log  string
+		want bool
+	}{
+		{"fatal Error line", "[SwiftLM] Loading model: /x\nError: File not found: main\n", true},
+		{"missing arg error", "Error: Missing expected argument '--model <model>'\n", true},
+		{"info only", "[SwiftLM] Loading model: /ok\n[SwiftLM] Ready\n", false},
+		{"empty", "", false},
+		{"lowercase error not matched", "error: something\n", false},
+	}
+	r := NewSwiftLMRuntime(nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "log")
+			if err := os.WriteFile(path, []byte(tt.log), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if got := r.IsStartupError(path); got != tt.want {
+				t.Errorf("IsStartupError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSwiftLMHealthURL(t *testing.T) {
+	r := NewSwiftLMRuntime(nil)
+	if got := r.HealthURL("localhost", 7000); got != "http://localhost:7000/health" {
+		t.Errorf("HealthURL = %q", got)
+	}
+}
+
+func TestSwiftLMKindIsMLX(t *testing.T) {
+	if k := NewSwiftLMRuntime(nil).Kind(); k != BackendKindMLX {
+		t.Errorf("Kind() = %v, want mlx", k)
+	}
+}

--- a/internal/proxy/backend_swiftlm_test.go
+++ b/internal/proxy/backend_swiftlm_test.go
@@ -105,8 +105,19 @@ func TestSwiftLMIsStartupError(t *testing.T) {
 		log  string
 		want bool
 	}{
+		// ArgumentParser validation / explicit error lines.
 		{"fatal Error line", "[SwiftLM] Loading model: /x\nError: File not found: main\n", true},
 		{"missing arg error", "Error: Missing expected argument '--model <model>'\n", true},
+
+		// Swift runtime aborts (OOM, forced-try, fatalError).
+		{"Fatal error prefix", "Fatal error: Unexpectedly found nil\n", true},
+		{"forced-try swift stack", "Swift/ErrorType.swift:200: Fatal error: 'try!' expression\n", true},
+		{"thread 1 fatal", "Thread 1: Fatal error: index out of range\n", true},
+
+		// dyld load failures (missing metallib / dylib).
+		{"dyld library not loaded", "dyld[12345]: Library not loaded: @rpath/libmlx.metallib\n", true},
+
+		// Negatives.
 		{"info only", "[SwiftLM] Loading model: /ok\n[SwiftLM] Ready\n", false},
 		{"empty", "", false},
 		{"lowercase error not matched", "error: something\n", false},

--- a/internal/proxy/manager.go
+++ b/internal/proxy/manager.go
@@ -12,20 +12,16 @@ package proxy
 // process), it must not re-acquire it while holding b.mu.
 
 import (
-	"bufio"
 	"fmt"
-	"maps"
 	"net/http"
 	"os"
 	"os/exec"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/nchapman/lleme/internal/config"
 	"github.com/nchapman/lleme/internal/hf"
-	"github.com/nchapman/lleme/internal/llama"
 	"github.com/nchapman/lleme/internal/logs"
 )
 
@@ -173,6 +169,7 @@ func (m *ModelManager) GetOrLoadBackend(modelQuery string, options map[string]an
 	backend = &Backend{
 		ModelName:    modelName,
 		ModelPath:    modelPath,
+		Runtime:      m.selectRuntime(modelPath, modelName),
 		Port:         port,
 		Status:       BackendStarting,
 		StartedAt:    time.Now(),
@@ -405,7 +402,7 @@ func (m *ModelManager) Resolver() *ModelResolver {
 	return m.resolver
 }
 
-// startBackend starts the llama-server process for a backend
+// startBackend starts the server process for a backend via its Runtime.
 func (m *ModelManager) startBackend(backend *Backend) {
 	defer func() {
 		// Ensure ReadyChan is closed even on error
@@ -414,12 +411,13 @@ func (m *ModelManager) startBackend(backend *Backend) {
 		}
 	}()
 
-	serverPath := llama.ServerPath()
-	args := m.buildArgs(backend)
+	rt := backend.Runtime
+	serverPath := rt.BinaryPath()
+	args := rt.BuildArgs(backend, m.config.Host)
 
 	cmd := exec.Command(serverPath, args...)
 	cmd.Env = os.Environ()
-	cmd.Dir = config.BinPath()
+	cmd.Dir = rt.WorkingDir()
 
 	// Create rotating log writer for this backend
 	logWriter, err := logs.NewRotatingWriter(logs.BackendLogPath(backend.ModelName))
@@ -462,96 +460,8 @@ func (m *ModelManager) startBackend(backend *Backend) {
 	}
 }
 
-func (m *ModelManager) buildArgs(backend *Backend) []string {
-	args := []string{
-		"--model", backend.ModelPath,
-		"--host", m.config.Host,
-		"--port", fmt.Sprintf("%d", backend.Port),
-		"--embeddings", // Enable /v1/embeddings endpoint
-		"--no-webui",   // Disable built-in web UI (lleme is a proxy)
-	}
-
-	// Check for mmproj file (vision model support)
-	if mmprojPath := findMMProjForModel(backend.ModelName); mmprojPath != "" {
-		args = append(args, "--mmproj", mmprojPath)
-	}
-
-	// Apply template patches to work around llama-server issues.
-	// See template.go for the patch registry and documentation.
-	if templatePath, err := ExtractAndPatchTemplate(backend.ModelPath); err == nil && templatePath != "" {
-		args = append(args, "--chat-template-file", templatePath)
-	}
-
-	// Merge config options with backend-specific options (backend overrides config)
-	mergedOptions := make(map[string]any)
-	maps.Copy(mergedOptions, m.appConfig.LlamaCpp.Options)
-	maps.Copy(mergedOptions, backend.Options)
-
-	// Pass through all llama-server options
-	args = append(args, buildLlamaServerArgs(mergedOptions)...)
-
-	return args
-}
-
-// findMMProjForModel parses the model name and checks if an mmproj file exists.
-// ModelName format: "user/repo:quant" (e.g., "ggml-org/gemma-3-4b-it-GGUF:Q4_K_M")
-func findMMProjForModel(modelName string) string {
-	parts := strings.Split(modelName, ":")
-	if len(parts) != 2 {
-		return ""
-	}
-
-	repoRef := parts[0]
-	quant := parts[1]
-
-	repoParts := strings.Split(repoRef, "/")
-	if len(repoParts) != 2 {
-		return ""
-	}
-
-	user := repoParts[0]
-	repo := repoParts[1]
-
-	return hf.FindMMProjFile(user, repo, quant)
-}
-
-// buildLlamaServerArgs converts the llama_server config map to command-line arguments.
-func buildLlamaServerArgs(config map[string]any) []string {
-	if config == nil {
-		return nil
-	}
-
-	var args []string
-	for key, value := range config {
-		flag := "--" + key
-
-		switch v := value.(type) {
-		case bool:
-			if v {
-				args = append(args, flag)
-			}
-			// false booleans are omitted (use default)
-		case int:
-			args = append(args, flag, fmt.Sprintf("%d", v))
-		case float64:
-			// YAML parses numbers as float64, check if it's a whole number
-			if v == float64(int(v)) {
-				args = append(args, flag, fmt.Sprintf("%d", int(v)))
-			} else {
-				args = append(args, flag, fmt.Sprintf("%g", v))
-			}
-		case string:
-			if v != "" {
-				args = append(args, flag, v)
-			}
-		}
-	}
-
-	return args
-}
-
 func (m *ModelManager) waitForReady(backend *Backend) error {
-	healthURL := fmt.Sprintf("http://%s:%d/health", m.config.Host, backend.Port)
+	healthURL := backend.Runtime.HealthURL(m.config.Host, backend.Port)
 	client := &http.Client{Timeout: 2 * time.Second}
 
 	logPath := logs.BackendLogPath(backend.ModelName)
@@ -568,7 +478,7 @@ func (m *ModelManager) waitForReady(backend *Backend) error {
 		}
 
 		// Check log for errors
-		if hasStartupError(logPath) {
+		if backend.Runtime.IsStartupError(logPath) {
 			return fmt.Errorf("server startup failed (check %s)", logPath)
 		}
 
@@ -576,26 +486,6 @@ func (m *ModelManager) waitForReady(backend *Backend) error {
 	}
 
 	return fmt.Errorf("server did not become ready within %v", m.config.StartupTimeout)
-}
-
-func hasStartupError(logFile string) bool {
-	file, err := os.Open(logFile)
-	if err != nil {
-		return false
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.ToLower(scanner.Text())
-		if strings.Contains(line, "error") && strings.Contains(line, "failed") {
-			return true
-		}
-		if strings.Contains(line, "could not load model") {
-			return true
-		}
-	}
-	return false
 }
 
 func (m *ModelManager) updateLRU(modelName string) {

--- a/internal/proxy/manager.go
+++ b/internal/proxy/manager.go
@@ -158,6 +158,14 @@ func (m *ModelManager) GetOrLoadBackend(modelQuery string, options map[string]an
 		m.mu.Lock()
 	}
 
+	// Resolve which runtime serves this model before we commit to any
+	// resources (port, LRU entry) so a bad metadata entry fails cleanly.
+	runtime, err := m.selectRuntime(result.Model.User, result.Model.Repo, result.Model.Quant)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+
 	// Allocate port
 	port, err := m.portAllocator.Allocate()
 	if err != nil {
@@ -169,7 +177,7 @@ func (m *ModelManager) GetOrLoadBackend(modelQuery string, options map[string]an
 	backend = &Backend{
 		ModelName:    modelName,
 		ModelPath:    modelPath,
-		Runtime:      m.selectRuntime(modelPath, modelName),
+		Runtime:      runtime,
 		Port:         port,
 		Status:       BackendStarting,
 		StartedAt:    time.Now(),

--- a/internal/proxy/manager.go
+++ b/internal/proxy/manager.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -109,7 +110,7 @@ func (m *ModelManager) GetOrLoadBackend(modelQuery string, options map[string]an
 		switch status := backend.GetStatus(); status {
 		case BackendReady:
 			// Check if options changed - if so, reload the model
-			if optionsChanged(backend.Options, options) {
+			if optionsChanged(backend.Runtime, backend.Options, options) {
 				// Mark as stopping to prevent race conditions
 				backend.SetStatus(BackendStopping)
 				m.mu.Unlock()
@@ -223,7 +224,7 @@ func (m *ModelManager) finalizeReadyBackend(modelQuery, modelName string, backen
 		m.mu.Unlock()
 		return m.GetOrLoadBackend(modelQuery, options)
 	}
-	if optionsChanged(backend.Options, options) {
+	if optionsChanged(backend.Runtime, backend.Options, options) {
 		m.mu.Unlock()
 		if err := m.StopBackend(modelName); err != nil {
 			return nil, fmt.Errorf("reload with new options: %w", err)
@@ -555,7 +556,13 @@ func (e *ModelNotFoundError) Error() string {
 // optionsChanged returns true if the new options differ from the current options.
 // Only compares options that affect model loading (server options).
 // Returns false if both are nil/empty, or if they have the same values.
-func optionsChanged(current, new map[string]any) bool {
+// optionsChanged reports whether the given new options would require
+// reloading the backend currently serving the model. Uses the Runtime's
+// SignificantOptions() list so the set of reload-worthy keys is a
+// per-backend concern. Maps are normalized to kebab-case before lookup so
+// `turbo_kv` from YAML and `turbo-kv` from a CLI flag compare equal.
+// Nil / empty on either side is handled early.
+func optionsChanged(runtime Runtime, current, new map[string]any) bool {
 	// If new options are nil/empty, no change requested
 	if len(new) == 0 {
 		return false
@@ -566,12 +573,14 @@ func optionsChanged(current, new map[string]any) bool {
 		return true
 	}
 
-	// Compare the options that matter for model loading
-	serverOptions := []string{"ctx-size", "gpu-layers", "threads", "batch-size", "ubatch-size", "flash-attn", "mlock", "cache-type-k", "cache-type-v"}
-
-	for _, key := range serverOptions {
-		newVal, newExists := new[key]
-		curVal, curExists := current[key]
+	// Compare the options that matter for this runtime's model loading.
+	// Each Runtime declares its own list so changing a llama-only key
+	// doesn't trigger a reload on SwiftLM (and vice versa).
+	curNorm := normalizeOptionKeys(current)
+	newNorm := normalizeOptionKeys(new)
+	for _, key := range runtime.SignificantOptions() {
+		newVal, newExists := newNorm[key]
+		curVal, curExists := curNorm[key]
 
 		if newExists != curExists {
 			return true
@@ -582,6 +591,21 @@ func optionsChanged(current, new map[string]any) bool {
 	}
 
 	return false
+}
+
+// normalizeOptionKeys returns m with every key's `_` replaced by `-`.
+// Input maps can mix forms (YAML supplies snake_case by convention; CLI
+// flags produce kebab-case); this lets comparisons happen on a single
+// vocabulary without the caller having to normalize upstream.
+func normalizeOptionKeys(m map[string]any) map[string]any {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[strings.ReplaceAll(k, "_", "-")] = v
+	}
+	return out
 }
 
 // optionValuesEqual compares two option values, handling type coercion.

--- a/internal/proxy/manager_test.go
+++ b/internal/proxy/manager_test.go
@@ -199,13 +199,39 @@ func TestOptionsChanged(t *testing.T) {
 		},
 	}
 
+	rt := NewLlamaRuntime(nil)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := optionsChanged(tt.current, tt.new)
+			result := optionsChanged(rt, tt.current, tt.new)
 			if result != tt.expected {
 				t.Errorf("optionsChanged(%v, %v) = %v, want %v", tt.current, tt.new, result, tt.expected)
 			}
 		})
+	}
+}
+
+// Each runtime has its own reload-worthy key list. A SwiftLM-only flag
+// change must trigger a reload when the backend is SwiftLM, and NOT when
+// the backend is llama (which ignores it).
+func TestOptionsChangedPerRuntime(t *testing.T) {
+	cur := map[string]any{"turbo-kv": false}
+	next := map[string]any{"turbo-kv": true}
+
+	if !optionsChanged(NewSwiftLMRuntime(nil), cur, next) {
+		t.Error("SwiftLM: turbo-kv change should trigger a reload")
+	}
+	if optionsChanged(NewLlamaRuntime(nil), cur, next) {
+		t.Error("llama: turbo-kv is not a llama option; should not trigger a reload")
+	}
+
+	// Symmetric check: mirostat matters to llama, not SwiftLM.
+	cur = map[string]any{"flash-attn": "auto"}
+	next = map[string]any{"flash-attn": "on"}
+	if !optionsChanged(NewLlamaRuntime(nil), cur, next) {
+		t.Error("llama: flash-attn change should trigger a reload")
+	}
+	if optionsChanged(NewSwiftLMRuntime(nil), cur, next) {
+		t.Error("SwiftLM: flash-attn is not a SwiftLM option; should not trigger a reload")
 	}
 }
 

--- a/internal/proxy/registry.go
+++ b/internal/proxy/registry.go
@@ -1,0 +1,29 @@
+package proxy
+
+// AllRuntimes returns one instance of every known Runtime. The instances are
+// constructed with a nil config — callers that only need backend-agnostic
+// metadata (HFAppName, Kind) can use them directly; anything that touches
+// options or starts a process should go through selectRuntime instead.
+//
+// This is the extension point for a new backend: implement Runtime, add a
+// constructor call here, and discovery/search picks it up automatically.
+func AllRuntimes() []Runtime {
+	return []Runtime{
+		NewLlamaRuntime(nil),
+		NewSwiftLMRuntime(nil),
+	}
+}
+
+// HFAppNames returns the HuggingFace "apps=" filter values for every
+// registered runtime, in registration order. Used by search and trending
+// to avoid hardcoding "llama.cpp" at the call site.
+func HFAppNames() []string {
+	rts := AllRuntimes()
+	out := make([]string, 0, len(rts))
+	for _, r := range rts {
+		if name := r.HFAppName(); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}

--- a/internal/proxy/resolver.go
+++ b/internal/proxy/resolver.go
@@ -2,8 +2,6 @@ package proxy
 
 import (
 	"fmt"
-	"io/fs"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -11,13 +9,17 @@ import (
 	"github.com/nchapman/lleme/internal/hf"
 )
 
-// DownloadedModel represents a model that has been downloaded locally
+// DownloadedModel represents a model that has been downloaded locally.
+// Backend is the runtime kind (hf.BackendGGUF | hf.BackendMLX). ModelPath
+// is the file llama-server would open (single GGUF or first split) or the
+// MLX directory SwiftLM is pointed at.
 type DownloadedModel struct {
 	User      string
 	Repo      string
 	Quant     string
+	Backend   string
 	FullName  string // "user/repo:quant"
-	ModelPath string // Absolute path to .gguf file
+	ModelPath string
 }
 
 // ModelResolver handles fuzzy matching of model names against downloaded models
@@ -32,80 +34,35 @@ func NewModelResolver() *ModelResolver {
 	}
 }
 
-// ListDownloadedModels returns all downloaded models
+// ListDownloadedModels returns every locally-downloaded model. Delegates to
+// the metadata-driven hf.ListLocalModels so MLX trees are first-class;
+// ModelPath is adjusted for GGUF split layouts so llama-server gets the
+// first shard path it expects.
 func (r *ModelResolver) ListDownloadedModels() ([]DownloadedModel, error) {
-	var models []DownloadedModel
-	seenSplitDirs := make(map[string]bool)
-
-	err := filepath.WalkDir(r.modelsPath, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return fmt.Errorf("walk %s: %w", path, err)
-		}
-		if d.IsDir() || filepath.Ext(d.Name()) != ".gguf" {
-			return nil
-		}
-		if hf.IsMMProjFileName(d.Name()) {
-			return nil
-		}
-
-		relPath, err := filepath.Rel(r.modelsPath, path)
-		if err != nil {
-			return fmt.Errorf("relative path of %s: %w", path, err)
-		}
-
-		parts := strings.Split(relPath, string(filepath.Separator))
-		if len(parts) < 3 {
-			return nil
-		}
-
-		user, repo := parts[0], parts[1]
-
-		if m, ok := classifyGGUFEntry(user, repo, parts, path, seenSplitDirs); ok {
-			models = append(models, m)
-		}
-
-		return nil
-	})
-
+	locals, err := hf.ListLocalModelsInDir(r.modelsPath)
 	if err != nil {
 		return nil, fmt.Errorf("list downloaded models: %w", err)
 	}
-
-	return models, nil
-}
-
-// classifyGGUFEntry determines whether a GGUF file is a split or single-file model
-// and returns the corresponding DownloadedModel. Returns (model, false) if the file
-// should be skipped (e.g., a duplicate split shard).
-func classifyGGUFEntry(user, repo string, parts []string, path string, seenSplitDirs map[string]bool) (DownloadedModel, bool) {
-	if len(parts) == 4 && hf.SplitFilePattern.MatchString(filepath.Base(path)) {
-		quant := parts[2]
-		key := filepath.Join(user, repo, quant)
-		if seenSplitDirs[key] {
-			return DownloadedModel{}, false
+	out := make([]DownloadedModel, 0, len(locals))
+	for _, m := range locals {
+		path := m.Path
+		// Inventory returns the quant directory for split GGUF; llama-server
+		// wants the first shard. MLX stays as the directory.
+		if m.Backend == hf.BackendGGUF && !strings.HasSuffix(path, ".gguf") {
+			if first := hf.FindFirstSplitFile(path); first != "" {
+				path = first
+			}
 		}
-		seenSplitDirs[key] = true
-		firstPath := hf.FindFirstSplitFile(filepath.Dir(path))
-		if firstPath == "" {
-			firstPath = path
-		}
-		return DownloadedModel{
-			User:      user,
-			Repo:      repo,
-			Quant:     quant,
-			FullName:  fmt.Sprintf("%s/%s:%s", user, repo, quant),
-			ModelPath: firstPath,
-		}, true
+		out = append(out, DownloadedModel{
+			User:      m.User,
+			Repo:      m.Repo,
+			Quant:     m.Quant,
+			Backend:   m.Backend,
+			FullName:  fmt.Sprintf("%s/%s:%s", m.User, m.Repo, m.Quant),
+			ModelPath: path,
+		})
 	}
-
-	quant := strings.TrimSuffix(filepath.Base(path), ".gguf")
-	return DownloadedModel{
-		User:      user,
-		Repo:      repo,
-		Quant:     quant,
-		FullName:  fmt.Sprintf("%s/%s:%s", user, repo, quant),
-		ModelPath: path,
-	}, true
+	return out, nil
 }
 
 // ResolveResult contains the result of a model resolution

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -275,11 +275,11 @@ func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request)
 		if msg == "" {
 			msg = fmt.Sprintf("backend returned %d", resp.StatusCode)
 		}
-		s.writeAnthropicError(w, requestID, resp.StatusCode, AnthropicAPIError, msg)
+		s.writeAnthropicError(w, requestID, resp.StatusCode, anthropicErrorTypeForStatus(resp.StatusCode), msg)
 		return
 	}
 
-	messageID := "msg_" + strings.TrimPrefix(requestID, "req_")
+	messageID := generateMessageID()
 	if stream {
 		s.writeAnthropicStream(w, resp.Body, requestID, messageID, modelName)
 		return
@@ -496,6 +496,16 @@ func generateRequestID() string {
 	b := make([]byte, 12)
 	_, _ = rand.Read(b)
 	return "req_" + hex.EncodeToString(b)
+}
+
+// generateMessageID creates an Anthropic-style msg_<random> ID. Kept
+// independent from requestID so clients can't use one to derive the other
+// — the two live in different namespaces (request is ephemeral; message is
+// a resource identifier).
+func generateMessageID() string {
+	b := make([]byte, 12)
+	_, _ = rand.Read(b)
+	return "msg_" + hex.EncodeToString(b)
 }
 
 // writeAnthropicError writes an Anthropic-compatible error response

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -425,43 +425,20 @@ func (s *Server) writeAnthropicTranslationError(w http.ResponseWriter, requestID
 }
 
 // proxyToBackend handles the common logic of extracting model and proxying
+// an OpenAI-style request verbatim to the resolved backend.
 func (s *Server) proxyToBackend(w http.ResponseWriter, r *http.Request, path string) {
-	if r.Method != http.MethodPost {
-		s.writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Only POST is allowed")
+	body, ok := s.readOpenAIBody(w, r)
+	if !ok {
 		return
 	}
-
-	// Cap inbound body to prevent unbounded memory use.
-	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			s.writeError(w, http.StatusRequestEntityTooLarge, "invalid_request",
-				fmt.Sprintf("Request body exceeds %d bytes", maxRequestBodyBytes))
-			return
-		}
-		s.writeError(w, http.StatusBadRequest, "invalid_request", "Failed to read request body")
-		return
-	}
-	r.Body.Close()
-
-	var req struct {
-		Model string `json:"model"`
-	}
-	if err := json.Unmarshal(body, &req); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid_request", "Failed to parse request body")
-		return
-	}
-
-	if req.Model == "" {
-		s.writeError(w, http.StatusBadRequest, "invalid_request", "Model field is required")
+	modelName, ok := s.extractOpenAIModel(w, body)
+	if !ok {
 		return
 	}
 
 	// Get or load the backend (no options override for chat endpoint).
 	// GetOrLoadBackend reserves the backend via AcquireRequest; we release on return.
-	backend, err := s.manager.GetOrLoadBackend(req.Model, nil)
+	backend, err := s.manager.GetOrLoadBackend(modelName, nil)
 	if err != nil {
 		s.handleModelError(w, err)
 		return
@@ -489,6 +466,47 @@ func (s *Server) proxyToBackend(w http.ResponseWriter, r *http.Request, path str
 	r.URL.Path = path
 
 	proxy.ServeHTTP(w, r)
+}
+
+// readOpenAIBody reads and size-caps the request body for an OpenAI-style
+// endpoint, writing an OpenAI-shaped error on failure. Returns (body, true)
+// on success, (nil, false) after writing an error.
+func (s *Server) readOpenAIBody(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	if r.Method != http.MethodPost {
+		s.writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Only POST is allowed")
+		return nil, false
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			s.writeError(w, http.StatusRequestEntityTooLarge, "invalid_request",
+				fmt.Sprintf("Request body exceeds %d bytes", maxRequestBodyBytes))
+			return nil, false
+		}
+		s.writeError(w, http.StatusBadRequest, "invalid_request", "Failed to read request body")
+		return nil, false
+	}
+	r.Body.Close()
+	return body, true
+}
+
+// extractOpenAIModel pulls the model field out of an OpenAI-style request
+// body, writing an OpenAI-shaped error on failure.
+func (s *Server) extractOpenAIModel(w http.ResponseWriter, body []byte) (string, bool) {
+	var req struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		s.writeError(w, http.StatusBadRequest, "invalid_request", "Failed to parse request body")
+		return "", false
+	}
+	if req.Model == "" {
+		s.writeError(w, http.StatusBadRequest, "invalid_request", "Model field is required")
+		return "", false
+	}
+	return req.Model, true
 }
 
 // generateRequestID creates a unique request ID in Anthropic format

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -229,14 +229,199 @@ func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
 	s.proxyToBackend(w, r, "/v1/embeddings")
 }
 
-// handleAnthropicMessages proxies Anthropic Messages API requests
+// handleAnthropicMessages translates an Anthropic /v1/messages request into
+// an OpenAI chat completion, forwards it to the selected backend, and
+// translates the response back. Translation happens in the proxy so backends
+// (llama-server, SwiftLM) only need to speak OpenAI.
 func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request) {
-	s.proxyToBackendAnthropic(w, r, "/v1/messages")
+	requestID := generateRequestID()
+
+	body, ok := s.readAnthropicBody(w, r, requestID)
+	if !ok {
+		return
+	}
+
+	modelName, ok := s.extractAnthropicModel(w, requestID, body)
+	if !ok {
+		return
+	}
+
+	openAIBody, stream, err := translateAnthropicRequest(body)
+	if err != nil {
+		s.writeAnthropicTranslationError(w, requestID, err)
+		return
+	}
+
+	backend, err := s.manager.GetOrLoadBackend(modelName, nil)
+	if err != nil {
+		s.handleAnthropicModelError(w, requestID, err)
+		return
+	}
+	defer backend.ReleaseRequest()
+
+	resp, err := s.forwardToBackendChat(r.Context(), backend, openAIBody, stream)
+	if err != nil {
+		s.writeAnthropicError(w, requestID, http.StatusBadGateway, AnthropicAPIError, "Backend request failed: "+err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Cap the error body we buffer & echo back — a misbehaving backend
+		// shouldn't cause the proxy to hold a multi-MB error string in memory
+		// or leak arbitrarily large internals to the caller.
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
+		msg := strings.TrimSpace(string(errBody))
+		if msg == "" {
+			msg = fmt.Sprintf("backend returned %d", resp.StatusCode)
+		}
+		s.writeAnthropicError(w, requestID, resp.StatusCode, AnthropicAPIError, msg)
+		return
+	}
+
+	messageID := "msg_" + strings.TrimPrefix(requestID, "req_")
+	if stream {
+		s.writeAnthropicStream(w, resp.Body, requestID, messageID, modelName)
+		return
+	}
+	s.writeAnthropicNonStream(w, resp.Body, requestID, messageID)
 }
 
-// handleAnthropicCountTokens proxies Anthropic token counting requests
+// extractAnthropicModel pulls the model field out of an Anthropic request
+// body and writes an error response if missing or malformed.
+func (s *Server) extractAnthropicModel(w http.ResponseWriter, requestID string, body []byte) (string, bool) {
+	var modelRef struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(body, &modelRef); err != nil {
+		s.writeAnthropicError(w, requestID, http.StatusBadRequest, AnthropicInvalidRequest, "Failed to parse request body as JSON")
+		return "", false
+	}
+	if modelRef.Model == "" {
+		s.writeAnthropicError(w, requestID, http.StatusBadRequest, AnthropicInvalidRequest, "model: Field required")
+		return "", false
+	}
+	return modelRef.Model, true
+}
+
+// forwardToBackendChat POSTs a translated OpenAI request to the backend's
+// /v1/chat/completions endpoint and returns the raw response.
+func (s *Server) forwardToBackendChat(ctx context.Context, backend *Backend, openAIBody []byte, stream bool) (*http.Response, error) {
+	backendURL := fmt.Sprintf("http://%s:%d/v1/chat/completions", s.config.Host, backend.Port)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, backendURL, bytes.NewReader(openAIBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if stream {
+		req.Header.Set("Accept", "text/event-stream")
+	}
+	return backendChatClient.Do(req)
+}
+
+// writeAnthropicStream sets SSE headers and pumps the translated stream.
+// Errors after the header has been written can't be surfaced to the client
+// as HTTP status; log them for debugging.
+func (s *Server) writeAnthropicStream(w http.ResponseWriter, body io.Reader, requestID, messageID, model string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("request-id", requestID)
+	w.WriteHeader(http.StatusOK)
+
+	if err := translateAnthropicStream(w, body, messageID, model); err != nil {
+		logs.Debug("anthropic stream translation ended with error", "error", err)
+	}
+}
+
+// writeAnthropicNonStream reads the full backend response, translates to
+// Anthropic format, and writes it.
+func (s *Server) writeAnthropicNonStream(w http.ResponseWriter, body io.Reader, requestID, messageID string) {
+	respBody, err := io.ReadAll(body)
+	if err != nil {
+		s.writeAnthropicError(w, requestID, http.StatusBadGateway, AnthropicAPIError, "Failed to read backend response")
+		return
+	}
+	translated, err := translateOpenAIResponse(respBody, messageID)
+	if err != nil {
+		s.writeAnthropicError(w, requestID, http.StatusInternalServerError, AnthropicAPIError, "Translation error: "+err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("request-id", requestID)
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(translated); err != nil {
+		logs.Debug("failed to write anthropic response", "error", err)
+	}
+}
+
+// handleAnthropicCountTokens returns an approximate input-token count for an
+// Anthropic /v1/messages/count_tokens request. Backends don't expose an
+// OpenAI-equivalent tokenize endpoint uniformly, so we approximate on the
+// proxy side. The estimate leans toward overcounting so callers plan
+// conservatively; see countAnthropicTokens for the ratio.
 func (s *Server) handleAnthropicCountTokens(w http.ResponseWriter, r *http.Request) {
-	s.proxyToBackendAnthropic(w, r, "/v1/messages/count_tokens")
+	requestID := generateRequestID()
+
+	body, ok := s.readAnthropicBody(w, r, requestID)
+	if !ok {
+		return
+	}
+
+	count, err := countAnthropicTokens(body)
+	if err != nil {
+		s.writeAnthropicTranslationError(w, requestID, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("request-id", requestID)
+	w.WriteHeader(http.StatusOK)
+	writeJSON(w, map[string]int{"input_tokens": count})
+}
+
+// backendChatClient forwards translated requests to a local backend. No
+// timeout: streaming completions can run for minutes, and request-context
+// cancelation already covers the disconnect case. Named to avoid reading
+// like an Anthropic cloud client — the target is always a local backend.
+var backendChatClient = &http.Client{}
+
+// readAnthropicBody reads and size-caps the request body, writing an Anthropic
+// error response on failure. Returns (body, true) on success, or (nil, false)
+// after writing an error response.
+func (s *Server) readAnthropicBody(w http.ResponseWriter, r *http.Request, requestID string) ([]byte, bool) {
+	if r.Method != http.MethodPost {
+		s.writeAnthropicError(w, requestID, http.StatusMethodNotAllowed, AnthropicInvalidRequest, "Only POST is allowed")
+		return nil, false
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			s.writeAnthropicError(w, requestID, http.StatusRequestEntityTooLarge, AnthropicInvalidRequest,
+				fmt.Sprintf("Request body exceeds %d bytes", maxRequestBodyBytes))
+			return nil, false
+		}
+		s.writeAnthropicError(w, requestID, http.StatusBadRequest, AnthropicInvalidRequest, "Failed to read request body")
+		return nil, false
+	}
+	r.Body.Close()
+	// Strip Anthropic client auth headers before any downstream forwarding.
+	r.Header.Del("x-api-key")
+	return body, true
+}
+
+// writeAnthropicTranslationError maps a translation error to an Anthropic
+// HTTP response. translateError carries the intended status and error type;
+// other errors surface as 500 api_error.
+func (s *Server) writeAnthropicTranslationError(w http.ResponseWriter, requestID string, err error) {
+	var te *translateError
+	if errors.As(err, &te) {
+		s.writeAnthropicError(w, requestID, te.status, te.errType, te.msg)
+		return
+	}
+	s.writeAnthropicError(w, requestID, http.StatusInternalServerError, AnthropicAPIError, err.Error())
 }
 
 // proxyToBackend handles the common logic of extracting model and proxying
@@ -302,86 +487,6 @@ func (s *Server) proxyToBackend(w http.ResponseWriter, r *http.Request, path str
 	r.Body = io.NopCloser(bytes.NewReader(body))
 	r.ContentLength = int64(len(body))
 	r.URL.Path = path
-
-	proxy.ServeHTTP(w, r)
-}
-
-// proxyToBackendAnthropic handles Anthropic API requests with proper error format
-func (s *Server) proxyToBackendAnthropic(w http.ResponseWriter, r *http.Request, path string) {
-	requestID := generateRequestID()
-
-	if r.Method != http.MethodPost {
-		s.writeAnthropicError(w, requestID, http.StatusMethodNotAllowed, AnthropicInvalidRequest, "Only POST is allowed")
-		return
-	}
-
-	// Cap inbound body to prevent unbounded memory use.
-	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			s.writeAnthropicError(w, requestID, http.StatusRequestEntityTooLarge, AnthropicInvalidRequest,
-				fmt.Sprintf("Request body exceeds %d bytes", maxRequestBodyBytes))
-			return
-		}
-		s.writeAnthropicError(w, requestID, http.StatusBadRequest, AnthropicInvalidRequest, "Failed to read request body")
-		return
-	}
-	r.Body.Close()
-
-	var req struct {
-		Model string `json:"model"`
-	}
-	if err := json.Unmarshal(body, &req); err != nil {
-		s.writeAnthropicError(w, requestID, http.StatusBadRequest, AnthropicInvalidRequest, "Failed to parse request body as JSON")
-		return
-	}
-
-	if req.Model == "" {
-		s.writeAnthropicError(w, requestID, http.StatusBadRequest, AnthropicInvalidRequest, "model: Field required")
-		return
-	}
-
-	// Get or load the backend.
-	// GetOrLoadBackend reserves the backend via AcquireRequest; we release on return.
-	backend, err := s.manager.GetOrLoadBackend(req.Model, nil)
-	if err != nil {
-		s.handleAnthropicModelError(w, requestID, err)
-		return
-	}
-	defer backend.ReleaseRequest()
-
-	// Proxy the request
-	backendURL := fmt.Sprintf("http://%s:%d", s.config.Host, backend.Port)
-	target, err := url.Parse(backendURL)
-	if err != nil {
-		s.writeAnthropicError(w, requestID, http.StatusInternalServerError, AnthropicAPIError, "Internal server error")
-		return
-	}
-
-	proxy := httputil.NewSingleHostReverseProxy(target)
-
-	// Handle streaming responses properly
-	proxy.FlushInterval = -1 // Flush immediately for SSE
-
-	proxy.ModifyResponse = func(resp *http.Response) error {
-		resp.Header.Set("request-id", requestID)
-		return stripCORSHeaders(resp)
-	}
-
-	// Handle backend errors
-	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-		s.writeAnthropicError(w, requestID, http.StatusBadGateway, AnthropicAPIError, "Backend server error: "+err.Error())
-	}
-
-	// Restore the body for the proxied request
-	r.Body = io.NopCloser(bytes.NewReader(body))
-	r.ContentLength = int64(len(body))
-	r.URL.Path = path
-
-	// Strip Anthropic auth headers before forwarding (local server doesn't need them)
-	r.Header.Del("x-api-key")
 
 	proxy.ServeHTTP(w, r)
 }

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nchapman/lleme/internal/hf"
 	"github.com/nchapman/lleme/internal/llama"
 	"github.com/nchapman/lleme/internal/logs"
+	"github.com/nchapman/lleme/internal/swiftlm"
 	"github.com/nchapman/lleme/internal/version"
 )
 
@@ -115,50 +116,119 @@ func (s *Server) Start() error {
 	// Save initial state (no backends yet)
 	s.saveState()
 
-	// Check for llama.cpp updates in the background. Running backends keep using
-	// their currently-loaded binary; the new version is picked up on next model load.
+	// Check for backend updates in the background. Running backends keep using
+	// their currently-loaded binary; new versions are picked up on next model load.
 	ctx, cancel := context.WithCancel(context.Background())
 	s.autoUpdateCancel = cancel
 	go s.autoUpdateLlamaCpp(ctx)
+	go s.autoUpdateSwiftLM(ctx)
 
 	return nil
 }
 
-// autoUpdateLlamaCpp checks for a newer llama.cpp release and installs it in
-// the background. Runs on proxy startup. Failures are logged and do not affect
-// the proxy — the existing llama.cpp install remains functional. The context is
-// canceled on Stop so an in-flight download aborts rather than swapping the
-// llama-current symlink after shutdown.
-func (s *Server) autoUpdateLlamaCpp(ctx context.Context) {
-	if s.appConfig == nil || !s.appConfig.LlamaCpp.AutoUpdateEnabled() {
+// autoUpdateCheck bundles what one backend's NewerVersionAvailable +
+// identifiers resolve to before runBackendAutoUpdate drives the flow.
+type autoUpdateCheck struct {
+	name         string
+	enabled      bool
+	installedTag string
+	latestTag    string
+	haveLatest   bool
+	checkErr     error
+	install      func(context.Context) (string, error) // returns newly-installed tag
+}
+
+// runBackendAutoUpdate drives the check → install → log flow for one
+// backend. Failures never affect the proxy; the context is canceled on Stop
+// so an in-flight download aborts rather than swapping a symlink after
+// shutdown. Kept separate from the two per-backend constructors so the
+// shared logic isn't flagged as a duplicate.
+func runBackendAutoUpdate(ctx context.Context, c autoUpdateCheck) {
+	if !c.enabled {
 		return
 	}
-
-	latest, installed, err := llama.NewerVersionAvailable()
-	if err != nil {
-		logs.Debug("llama.cpp auto-update check failed", "error", err)
+	if c.checkErr != nil {
+		logs.Debug(c.name+" auto-update check failed", "error", c.checkErr)
 		return
 	}
-	if latest == nil {
+	if !c.haveLatest {
 		return
 	}
+	logs.Info("Auto-updating "+c.name+" in background", "from", c.installedTag, "to", c.latestTag)
 
-	fromTag := ""
-	if installed != nil {
-		fromTag = installed.TagName
-	}
-	logs.Info("Auto-updating llama.cpp in background", "from", fromTag, "to", latest.TagName)
-
-	info, err := llama.InstallReleaseForAutoUpdate(ctx, latest, nil)
+	newTag, err := c.install(ctx)
 	if err != nil {
 		if ctx.Err() != nil {
-			logs.Debug("llama.cpp auto-update canceled on shutdown", "error", err)
+			logs.Debug(c.name+" auto-update canceled on shutdown", "error", err)
 			return
 		}
-		logs.Warn("llama.cpp auto-update failed", "error", err)
+		logs.Warn(c.name+" auto-update failed", "error", err)
 		return
 	}
-	logs.Info("llama.cpp auto-update installed; new model loads will use this version", "version", info.TagName)
+	logs.Info(c.name+" auto-update installed; new model loads will use this version", "version", newTag)
+}
+
+// autoUpdateLlamaCpp runs the llama.cpp auto-update check + install. The
+// structural twin autoUpdateSwiftLM below duplicates the glue deliberately
+// — collapsing both into a generic helper would lose per-backend types at
+// package boundaries; the shared flow lives in runBackendAutoUpdate.
+//
+//nolint:dupl // backend-identity repetition; see doc comment above.
+func (s *Server) autoUpdateLlamaCpp(ctx context.Context) {
+	latest, installed, err := llama.NewerVersionAvailable()
+	installedTag, latestTag := "", ""
+	if installed != nil {
+		installedTag = installed.TagName
+	}
+	if latest != nil {
+		latestTag = latest.TagName
+	}
+	runBackendAutoUpdate(ctx, autoUpdateCheck{
+		name:         "llama.cpp",
+		enabled:      s.appConfig != nil && s.appConfig.LlamaCpp.AutoUpdateEnabled(),
+		installedTag: installedTag,
+		latestTag:    latestTag,
+		haveLatest:   latest != nil,
+		checkErr:     err,
+		install: func(ctx context.Context) (string, error) {
+			info, err := llama.InstallReleaseForAutoUpdate(ctx, latest, nil)
+			if err != nil {
+				return "", err
+			}
+			return info.TagName, nil
+		},
+	})
+}
+
+// autoUpdateSwiftLM runs the SwiftLM auto-update check + install. Gated on
+// the platform via swiftlm.NewerVersionAvailable returning nil on hosts
+// SwiftLM doesn't support. See autoUpdateLlamaCpp for the design note.
+//
+//nolint:dupl // backend-identity repetition; see autoUpdateLlamaCpp.
+func (s *Server) autoUpdateSwiftLM(ctx context.Context) {
+	latest, installed, err := swiftlm.NewerVersionAvailable()
+	installedTag, latestTag := "", ""
+	if installed != nil {
+		installedTag = installed.TagName
+	}
+	if latest != nil {
+		latestTag = latest.TagName
+	}
+	runBackendAutoUpdate(ctx, autoUpdateCheck{
+		name:         "SwiftLM",
+		enabled:      s.appConfig != nil && s.appConfig.SwiftLM.AutoUpdateEnabled(),
+		installedTag: installedTag,
+		latestTag:    latestTag,
+		haveLatest:   latest != nil,
+		checkErr:     err,
+		install: func(ctx context.Context) (string, error) {
+			info, err := swiftlm.InstallReleaseForAutoUpdate(ctx, latest, nil)
+			if err != nil {
+				return "", err
+			}
+			return info.TagName, nil
+		},
+	})
 }
 
 // Stop gracefully stops the proxy server

--- a/internal/proxy/state.go
+++ b/internal/proxy/state.go
@@ -119,8 +119,9 @@ func isProcessRunning(pid int) bool {
 	return process.Signal(syscall.Signal(0)) == nil
 }
 
-// CleanupOrphanedBackends kills any orphaned llama-server processes from a previous
-// proxy instance that crashed. Returns the number of processes killed.
+// CleanupOrphanedBackends kills any orphaned backend processes (llama-server
+// or SwiftLM) from a previous proxy instance that crashed. Returns the
+// number of processes killed.
 func CleanupOrphanedBackends() int {
 	state, err := LoadProxyState()
 	if err != nil || state == nil {
@@ -142,8 +143,10 @@ func CleanupOrphanedBackends() int {
 			continue
 		}
 
-		// Verify this is actually a llama-server process
-		if !isLlamaServerProcess(backend.PID) {
+		// Verify this is a known backend process before sending signals.
+		// We don't persist the backend kind in state, so the PID alone is
+		// matched against both llama-server and SwiftLM command names.
+		if !isKnownBackendProcess(backend.PID) {
 			continue
 		}
 
@@ -160,20 +163,32 @@ func CleanupOrphanedBackends() int {
 	return killed
 }
 
-// isLlamaServerProcess checks if the given PID is a llama-server process.
-// Uses ps command which works on both Linux and macOS.
-func isLlamaServerProcess(pid int) bool {
+// isKnownBackendProcess reports whether the PID's `ps -o comm=` output
+// matches one of the backend binaries lleme launches. Works on Linux and
+// macOS; on both, comm is the basename of the executable.
+func isKnownBackendProcess(pid int) bool {
 	cmd := exec.Command("ps", "-p", fmt.Sprintf("%d", pid), "-o", "comm=")
 	output, err := cmd.Output()
 	if err != nil {
 		return false
 	}
-	return containsLlamaServer(string(output))
+	return cmdlineMatchesBackend(string(output))
 }
 
-// containsLlamaServer checks if a command line contains llama-server
-func containsLlamaServer(cmdline string) bool {
-	return strings.Contains(cmdline, "llama-server") || strings.Contains(cmdline, "llama_server")
+// cmdlineMatchesBackend checks whether the given process command name
+// belongs to one of our backends.
+//
+// llama-server uses substring match because the process may appear under
+// shell wrappers on some installations (retaining the pre-SwiftLM posture).
+// SwiftLM uses exact-basename match after trimming whitespace — its name is
+// short enough that substring matching risks false positives against
+// user-named binaries (e.g. `MySwiftLMWrapper`) and the SwiftLM binary
+// always executes directly, so exact match is tight and sufficient.
+func cmdlineMatchesBackend(cmdline string) bool {
+	if strings.Contains(cmdline, "llama-server") || strings.Contains(cmdline, "llama_server") {
+		return true
+	}
+	return strings.TrimSpace(cmdline) == "SwiftLM"
 }
 
 // killProcess sends SIGTERM, waits briefly, then SIGKILL if needed

--- a/internal/proxy/state.go
+++ b/internal/proxy/state.go
@@ -176,19 +176,19 @@ func isKnownBackendProcess(pid int) bool {
 }
 
 // cmdlineMatchesBackend checks whether the given process command name
-// belongs to one of our backends.
-//
-// llama-server uses substring match because the process may appear under
-// shell wrappers on some installations (retaining the pre-SwiftLM posture).
-// SwiftLM uses exact-basename match after trimming whitespace — its name is
-// short enough that substring matching risks false positives against
-// user-named binaries (e.g. `MySwiftLMWrapper`) and the SwiftLM binary
-// always executes directly, so exact match is tight and sufficient.
+// belongs to one of our backends. `ps -o comm=` returns the executable's
+// basename, so exact-match is sufficient and safest: a reused PID whose
+// new process merely contains `llama-server` as a substring (wrapper
+// scripts, user binaries like `MyLlamaServerTool`) won't be misidentified
+// as ours. We always exec our own binaries directly via llama.ServerPath()
+// / swiftlm.ServerPath(), so comm is always one of these exact values.
 func cmdlineMatchesBackend(cmdline string) bool {
-	if strings.Contains(cmdline, "llama-server") || strings.Contains(cmdline, "llama_server") {
+	comm := strings.TrimSpace(cmdline)
+	switch comm {
+	case "llama-server", "llama_server", "SwiftLM":
 		return true
 	}
-	return strings.TrimSpace(cmdline) == "SwiftLM"
+	return false
 }
 
 // killProcess sends SIGTERM, waits briefly, then SIGKILL if needed

--- a/internal/proxy/state_test.go
+++ b/internal/proxy/state_test.go
@@ -209,23 +209,33 @@ func TestIsProcessRunning(t *testing.T) {
 }
 
 func TestCmdlineMatchesBackend(t *testing.T) {
+	// Inputs here match the shape `ps -o comm=` actually produces: the
+	// executable basename followed by a trailing newline, no arguments.
+	// Exact-basename match is what the implementation (and our threat model
+	// around PID reuse) requires; the old fixtures modeling /proc/cmdline's
+	// null-separated arg vector didn't reflect real ps output.
 	tests := []struct {
 		name     string
 		cmdline  string
 		expected bool
 	}{
 		{
-			name:     "llama-server in path",
-			cmdline:  "/usr/bin/llama-server\x00--model\x00test.gguf",
+			name:     "llama-server basename from ps",
+			cmdline:  "llama-server\n",
 			expected: true,
 		},
 		{
-			name:     "llama_server with underscore",
-			cmdline:  "/opt/llama_server\x00--port\x0049152",
+			name:     "llama_server underscore variant",
+			cmdline:  "llama_server\n",
 			expected: true,
 		},
 		{
-			name:     "SwiftLM via ps -o comm= (basename + newline)",
+			name:     "llama-server no trailing whitespace",
+			cmdline:  "llama-server",
+			expected: true,
+		},
+		{
+			name:     "SwiftLM basename from ps",
 			cmdline:  "SwiftLM\n",
 			expected: true,
 		},
@@ -235,24 +245,24 @@ func TestCmdlineMatchesBackend(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "llama-server substring must not false-positive",
+			cmdline:  "MyLlamaServerWrapper\n",
+			expected: false,
+		},
+		{
 			name:     "SwiftLM substring must not false-positive",
 			cmdline:  "MySwiftLMWrapper\n",
 			expected: false,
 		},
 		{
 			name:     "different process",
-			cmdline:  "/usr/bin/python\x00script.py",
+			cmdline:  "python\n",
 			expected: false,
 		},
 		{
 			name:     "empty cmdline",
 			cmdline:  "",
 			expected: false,
-		},
-		{
-			name:     "llama-server as argument",
-			cmdline:  "/bin/sh\x00-c\x00llama-server --model test",
-			expected: true,
 		},
 	}
 

--- a/internal/proxy/state_test.go
+++ b/internal/proxy/state_test.go
@@ -208,7 +208,7 @@ func TestIsProcessRunning(t *testing.T) {
 	}
 }
 
-func TestContainsLlamaServer(t *testing.T) {
+func TestCmdlineMatchesBackend(t *testing.T) {
 	tests := []struct {
 		name     string
 		cmdline  string
@@ -223,6 +223,21 @@ func TestContainsLlamaServer(t *testing.T) {
 			name:     "llama_server with underscore",
 			cmdline:  "/opt/llama_server\x00--port\x0049152",
 			expected: true,
+		},
+		{
+			name:     "SwiftLM via ps -o comm= (basename + newline)",
+			cmdline:  "SwiftLM\n",
+			expected: true,
+		},
+		{
+			name:     "SwiftLM no trailing whitespace",
+			cmdline:  "SwiftLM",
+			expected: true,
+		},
+		{
+			name:     "SwiftLM substring must not false-positive",
+			cmdline:  "MySwiftLMWrapper\n",
+			expected: false,
 		},
 		{
 			name:     "different process",
@@ -243,9 +258,9 @@ func TestContainsLlamaServer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := containsLlamaServer(tt.cmdline)
+			result := cmdlineMatchesBackend(tt.cmdline)
 			if result != tt.expected {
-				t.Errorf("containsLlamaServer(%q) = %v, want %v", tt.cmdline, result, tt.expected)
+				t.Errorf("cmdlineMatchesBackend(%q) = %v, want %v", tt.cmdline, result, tt.expected)
 			}
 		})
 	}

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -34,13 +34,15 @@ func (s BackendStatus) String() string {
 	}
 }
 
-// Backend represents a running llama-server instance for a specific model
+// Backend represents a running server instance for a specific model.
+// The serving process is produced by Runtime (llama-server, SwiftLM, ...).
 type Backend struct {
 	mu           sync.RWMutex
 	ModelName    string         // Full model reference: "bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M"
-	ModelPath    string         // Absolute path to the .gguf file
+	ModelPath    string         // Absolute path to the model (file for GGUF, directory for MLX)
+	Runtime      Runtime        // Strategy for starting/health-checking this backend (exposes Kind())
 	Port         int            // Port this backend is listening on
-	Process      *os.Process    // The llama-server process
+	Process      *os.Process    // The backend server process
 	LogWriter    io.WriteCloser // Log file writer for this backend
 	LastActivity time.Time      // Last time a request was made to this backend
 	StartedAt    time.Time      // When this backend was started

--- a/internal/swiftlm/binary.go
+++ b/internal/swiftlm/binary.go
@@ -113,7 +113,7 @@ func FindAssetForPlatform(release *binaryrelease.Release) (string, string, error
 type StatusFunc func(message string)
 
 // InstallLatest downloads and installs the latest SwiftLM release, swapping
-// the swiftlm-current symlink and pruning prior versions.
+// the swiftlm-current symlink and pruning all prior versions.
 func InstallLatest(status StatusFunc) (*VersionInfo, error) {
 	if !IsSupported() {
 		return nil, UnsupportedPlatformError{}
@@ -122,10 +122,48 @@ func InstallLatest(status StatusFunc) (*VersionInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get latest release: %w", err)
 	}
-	return installRelease(context.Background(), release, status)
+	return installRelease(context.Background(), release, status, 0)
 }
 
-func installRelease(ctx context.Context, release *binaryrelease.Release, status StatusFunc) (*VersionInfo, error) {
+// InstallReleaseForAutoUpdate installs a pre-fetched release and retains the
+// two most recent prior versions. Used by the background auto-update path:
+// while SwiftLM doesn't dlopen GPU plugins the way llama.cpp does, a
+// backend forked just before the symlink swap may still hold its binary
+// open via exec mapping; keeping recent predecessors on disk means rollback
+// or debugging has something to reach for. Older versions are pruned on
+// subsequent installs. The context bounds the download so proxy shutdown
+// can abort a long-running fetch.
+func InstallReleaseForAutoUpdate(ctx context.Context, release *binaryrelease.Release, status StatusFunc) (*VersionInfo, error) {
+	return installRelease(ctx, release, status, 2)
+}
+
+// NewerVersionAvailable returns the latest SwiftLM release when it differs
+// from what is installed, or nil when we're already current. Returns nil
+// when SwiftLM is not yet installed — the background auto-update path does
+// not bootstrap fresh installs. Also nil on unsupported platforms so the
+// caller can skip cleanly without branching on IsSupported() first.
+func NewerVersionAvailable() (*binaryrelease.Release, *VersionInfo, error) {
+	if !IsSupported() {
+		return nil, nil, nil
+	}
+	installed, err := GetInstalledVersion()
+	if err != nil {
+		return nil, nil, fmt.Errorf("read installed version: %w", err)
+	}
+	if installed == nil {
+		return nil, nil, nil
+	}
+	latest, err := GetLatestVersion()
+	if err != nil {
+		return nil, installed, fmt.Errorf("fetch latest release: %w", err)
+	}
+	if latest.TagName == installed.TagName {
+		return nil, installed, nil
+	}
+	return latest, installed, nil
+}
+
+func installRelease(ctx context.Context, release *binaryrelease.Release, status StatusFunc, keepPrior int) (*VersionInfo, error) {
 	downloadURL, assetName, err := FindAssetForPlatform(release)
 	if err != nil {
 		return nil, err
@@ -156,7 +194,7 @@ func installRelease(ctx context.Context, release *binaryrelease.Release, status 
 		return nil, fmt.Errorf("failed to extract archive: %w", err)
 	}
 
-	pruneOldVersions(binDir, release.TagName)
+	pruneOldVersions(binDir, release.TagName, keepPrior)
 
 	binPath := filepath.Join(binDir, currentLinkName, "SwiftLM")
 	info := &VersionInfo{
@@ -216,11 +254,13 @@ func extractTarGz(archivePath, destDir, tagName string) error {
 	return binaryrelease.SwapCurrentSymlink(destDir, currentLinkName, versionDir)
 }
 
-// pruneOldVersions removes swiftlm-b* directories other than the current one
-// and whatever the symlink actually resolves to. SwiftLM doesn't dlopen GPU
-// backend plugins the way llama.cpp does, so we don't need to keep prior
-// versions alive for in-flight processes.
-func pruneOldVersions(binDir, currentTag string) {
+// pruneOldVersions removes SwiftLM-b* directories other than (a) the one
+// named by currentTag, (b) whatever the swiftlm-current symlink actually
+// resolves to, and (c) the keepPrior most-recent of the rest, ordered by
+// mtime. keepPrior=0 means only the current version survives — today's
+// InstallLatest behavior. Auto-update uses keepPrior=2 as insurance for
+// backends forked just before the symlink swap.
+func pruneOldVersions(binDir, currentTag string, keepPrior int) {
 	spare := map[string]bool{versionedDirName(currentTag): true}
 	if target, err := os.Readlink(filepath.Join(binDir, currentLinkName)); err == nil {
 		spare[filepath.Base(target)] = true
@@ -253,8 +293,12 @@ func pruneOldVersions(binDir, currentTag string) {
 		prior = append(prior, candidate{name: name, mtime: info.ModTime()})
 	}
 
+	// Newest-first so the first keepPrior entries are retained.
 	sort.Slice(prior, func(i, j int) bool { return prior[i].mtime.After(prior[j].mtime) })
-	for _, c := range prior {
+	for i, c := range prior {
+		if i < keepPrior {
+			continue
+		}
 		os.RemoveAll(filepath.Join(binDir, c.name))
 	}
 }

--- a/internal/swiftlm/binary.go
+++ b/internal/swiftlm/binary.go
@@ -273,7 +273,18 @@ func SaveVersionInfo(info *VersionInfo) error {
 	if err != nil {
 		return fmt.Errorf("marshal version: %w", err)
 	}
-	return os.WriteFile(versionFilePath(), data, 0644)
+	// Write + rename so a concurrent update or a crash mid-write can't leave
+	// a truncated file that GetInstalledVersion would fail to unmarshal.
+	path := versionFilePath()
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("activate %s: %w", path, err)
+	}
+	return nil
 }
 
 // GetInstalledVersion reads the installed-version metadata, returning

--- a/internal/swiftlm/binary.go
+++ b/internal/swiftlm/binary.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -80,7 +79,7 @@ func releaseConfig() binaryrelease.Config {
 // GetLatestVersion resolves the latest SwiftLM release and validates the
 // tag matches b<number>.
 func GetLatestVersion() (*binaryrelease.Release, error) {
-	release, err := binaryrelease.FetchLatestRelease(releaseConfig(), apiBase+"/releases/latest")
+	release, err := binaryrelease.FetchLatestRelease(context.Background(), releaseConfig(), apiBase+"/releases/latest")
 	if err != nil {
 		return nil, err
 	}
@@ -178,8 +177,7 @@ func versionedDirName(tagName string) string {
 }
 
 func extractTarGz(archivePath, destDir, tagName string) error {
-	cmd := exec.Command("tar", "-xzf", archivePath, "-C", destDir)
-	if err := cmd.Run(); err != nil {
+	if err := binaryrelease.ExtractTarGz(archivePath, destDir); err != nil {
 		return fmt.Errorf("extract %s: %w", archivePath, err)
 	}
 	versionDir := versionedDirName(tagName)
@@ -210,9 +208,14 @@ func pruneOldVersions(binDir, currentTag string) {
 		mtime time.Time
 	}
 	var prior []candidate
+	const prefix = "SwiftLM-b"
+	const suffix = "-macos-arm64"
 	for _, entry := range entries {
 		name := entry.Name()
-		if !entry.IsDir() || !strings.HasPrefix(name, "SwiftLM-b") || spare[name] {
+		if !entry.IsDir() || spare[name] {
+			continue
+		}
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
 			continue
 		}
 		info, err := entry.Info()

--- a/internal/swiftlm/binary.go
+++ b/internal/swiftlm/binary.go
@@ -1,0 +1,279 @@
+// Package swiftlm manages the SwiftLM server binary — a self-contained
+// macOS/arm64 executable from SharpAI/SwiftLM that serves MLX models over
+// an OpenAI-compatible HTTP API. The lifecycle mirrors internal/llama:
+// resolve latest release → download tarball → extract → flip a "current"
+// symlink. Shared security-sensitive pieces (URL allow-list, download
+// caps, atomic symlink swap) live in internal/binaryrelease.
+package swiftlm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nchapman/lleme/internal/binaryrelease"
+	"github.com/nchapman/lleme/internal/config"
+	"github.com/nchapman/lleme/internal/version"
+)
+
+// swiftlmRepo is the GitHub repo we fetch releases from.
+const swiftlmRepo = "SharpAI/SwiftLM"
+
+// apiBase is overridable so tests can redirect to an httptest server.
+var apiBase = "https://api.github.com/repos/" + swiftlmRepo
+
+// maxDownloadBytes bounds the artifact size. SwiftLM is a single binary plus
+// its metallib shader library; the current release hovers around 50 MB. A
+// 1 GiB ceiling is generous. Declared var for test overrides.
+var maxDownloadBytes int64 = 1 << 30
+
+// tagNameRe matches SwiftLM release tag names (e.g. "b517"). Enforced on the
+// GitHub response so attacker-influenced values can't traverse out of binDir
+// via archive names, extracted directory names, or the swiftlm-current link.
+var tagNameRe = regexp.MustCompile(`^b\d+$`)
+
+// currentLinkName is the stable symlink callers invoke. It always resolves
+// to whichever swiftlm-<tag> directory is active.
+const currentLinkName = "swiftlm-current"
+
+// VersionInfo records an installed SwiftLM version in bin/swiftlm-version.json.
+// Kept in a sibling file (not merged into llama's version.json) so the two
+// installers stay independent.
+type VersionInfo struct {
+	TagName     string `json:"tag_name"`
+	BinaryPath  string `json:"binary_path"`
+	InstalledAt string `json:"installed_at"`
+}
+
+// IsSupported reports whether the current platform can run SwiftLM. The
+// upstream project ships only macOS/arm64 binaries.
+func IsSupported() bool {
+	return runtime.GOOS == "darwin" && runtime.GOARCH == "arm64"
+}
+
+// UnsupportedPlatformError is returned when install is attempted on a
+// platform the upstream project does not publish binaries for. Callers
+// use this to surface a clear user-facing message.
+type UnsupportedPlatformError struct{}
+
+func (UnsupportedPlatformError) Error() string {
+	return "SwiftLM (MLX) requires macOS on Apple Silicon"
+}
+
+func releaseConfig() binaryrelease.Config {
+	return binaryrelease.Config{
+		AllowedHosts:   binaryrelease.DefaultGitHubHosts(),
+		AllowedSchemes: binaryrelease.DefaultHTTPSOnly(),
+		MaxBytes:       maxDownloadBytes,
+		UserAgent:      version.UserAgent(),
+	}
+}
+
+// GetLatestVersion resolves the latest SwiftLM release and validates the
+// tag matches b<number>.
+func GetLatestVersion() (*binaryrelease.Release, error) {
+	release, err := binaryrelease.FetchLatestRelease(releaseConfig(), apiBase+"/releases/latest")
+	if err != nil {
+		return nil, err
+	}
+	if !tagNameRe.MatchString(release.TagName) {
+		return nil, fmt.Errorf("unexpected tag_name %q (expected b<number>)", release.TagName)
+	}
+	return release, nil
+}
+
+// expectedAssetName returns the tarball name SwiftLM publishes for the
+// current platform. Only macOS/arm64 is supported today.
+func expectedAssetName(tagName string) string {
+	return fmt.Sprintf("SwiftLM-%s-macos-arm64.tar.gz", tagName)
+}
+
+// FindAssetForPlatform picks the release asset matching the current platform.
+func FindAssetForPlatform(release *binaryrelease.Release) (string, string, error) {
+	if !IsSupported() {
+		return "", "", UnsupportedPlatformError{}
+	}
+	want := expectedAssetName(release.TagName)
+	for _, a := range release.Assets {
+		if a.Name == want {
+			return a.BrowserDownloadURL, a.Name, nil
+		}
+	}
+	return "", "", fmt.Errorf("could not find SwiftLM binary %s in release assets", want)
+}
+
+// StatusFunc is a progress-message callback used by Install.
+type StatusFunc func(message string)
+
+// InstallLatest downloads and installs the latest SwiftLM release, swapping
+// the swiftlm-current symlink and pruning prior versions.
+func InstallLatest(status StatusFunc) (*VersionInfo, error) {
+	if !IsSupported() {
+		return nil, UnsupportedPlatformError{}
+	}
+	release, err := GetLatestVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest release: %w", err)
+	}
+	return installRelease(context.Background(), release, status)
+}
+
+func installRelease(ctx context.Context, release *binaryrelease.Release, status StatusFunc) (*VersionInfo, error) {
+	downloadURL, assetName, err := FindAssetForPlatform(release)
+	if err != nil {
+		return nil, err
+	}
+
+	binDir := config.BinPath()
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create bin directory: %w", err)
+	}
+
+	// assetName came from FindAssetForPlatform → expectedAssetName, which
+	// hard-codes the prefix and suffix and substitutes a tag already matched
+	// against tagNameRe, so it cannot traverse outside binDir.
+	archivePath := filepath.Join(binDir, assetName)
+	defer os.Remove(archivePath)
+
+	if status != nil {
+		status(fmt.Sprintf("Downloading SwiftLM %s", release.TagName))
+	}
+	if err := binaryrelease.Download(ctx, releaseConfig(), downloadURL, archivePath, nil); err != nil {
+		return nil, fmt.Errorf("failed to download binary: %w", err)
+	}
+
+	if status != nil {
+		status("Extracting...")
+	}
+	if err := extractTarGz(archivePath, binDir, release.TagName); err != nil {
+		return nil, fmt.Errorf("failed to extract archive: %w", err)
+	}
+
+	pruneOldVersions(binDir, release.TagName)
+
+	binPath := filepath.Join(binDir, currentLinkName, "SwiftLM")
+	info := &VersionInfo{
+		TagName:     release.TagName,
+		BinaryPath:  binPath,
+		InstalledAt: time.Now().Format(time.RFC3339),
+	}
+	if err := SaveVersionInfo(info); err != nil {
+		return nil, fmt.Errorf("failed to save version info: %w", err)
+	}
+	return info, nil
+}
+
+// versionedDirName is the directory layout inside the SwiftLM tarball,
+// named to match the archive convention.
+func versionedDirName(tagName string) string {
+	return "SwiftLM-" + tagName + "-macos-arm64"
+}
+
+func extractTarGz(archivePath, destDir, tagName string) error {
+	cmd := exec.Command("tar", "-xzf", archivePath, "-C", destDir)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("extract %s: %w", archivePath, err)
+	}
+	versionDir := versionedDirName(tagName)
+	info, err := os.Stat(filepath.Join(destDir, versionDir))
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("expected directory %s not found in archive", versionDir)
+	}
+	return binaryrelease.SwapCurrentSymlink(destDir, currentLinkName, versionDir)
+}
+
+// pruneOldVersions removes swiftlm-b* directories other than the current one
+// and whatever the symlink actually resolves to. SwiftLM doesn't dlopen GPU
+// backend plugins the way llama.cpp does, so we don't need to keep prior
+// versions alive for in-flight processes.
+func pruneOldVersions(binDir, currentTag string) {
+	spare := map[string]bool{versionedDirName(currentTag): true}
+	if target, err := os.Readlink(filepath.Join(binDir, currentLinkName)); err == nil {
+		spare[filepath.Base(target)] = true
+	}
+
+	entries, err := os.ReadDir(binDir)
+	if err != nil {
+		return
+	}
+
+	type candidate struct {
+		name  string
+		mtime time.Time
+	}
+	var prior []candidate
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() || !strings.HasPrefix(name, "SwiftLM-b") || spare[name] {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		prior = append(prior, candidate{name: name, mtime: info.ModTime()})
+	}
+
+	sort.Slice(prior, func(i, j int) bool { return prior[i].mtime.After(prior[j].mtime) })
+	for _, c := range prior {
+		os.RemoveAll(filepath.Join(binDir, c.name))
+	}
+}
+
+// versionFilePath is the sibling file that records what's installed.
+func versionFilePath() string {
+	return filepath.Join(config.BinPath(), "swiftlm-version.json")
+}
+
+// SaveVersionInfo writes the installed-version metadata.
+func SaveVersionInfo(info *VersionInfo) error {
+	if err := os.MkdirAll(config.BinPath(), 0755); err != nil {
+		return fmt.Errorf("create bin dir: %w", err)
+	}
+	data, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal version: %w", err)
+	}
+	return os.WriteFile(versionFilePath(), data, 0644)
+}
+
+// GetInstalledVersion reads the installed-version metadata, returning
+// (nil, nil) if SwiftLM has never been installed.
+func GetInstalledVersion() (*VersionInfo, error) {
+	data, err := os.ReadFile(versionFilePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var info VersionInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// ServerPath returns the absolute path to the SwiftLM binary under the
+// current symlink. Caller is responsible for checking it actually exists.
+func ServerPath() string {
+	return filepath.Join(config.BinPath(), currentLinkName, "SwiftLM")
+}
+
+// IsInstalled reports whether a SwiftLM binary is present under the current
+// symlink. Returns false on unsupported platforms without hitting the disk.
+func IsInstalled() bool {
+	if !IsSupported() {
+		return false
+	}
+	_, err := os.Stat(ServerPath())
+	return err == nil
+}

--- a/internal/swiftlm/binary.go
+++ b/internal/swiftlm/binary.go
@@ -176,14 +176,42 @@ func versionedDirName(tagName string) string {
 	return "SwiftLM-" + tagName + "-macos-arm64"
 }
 
+// extractTarGz unpacks the SwiftLM tarball into a fresh versioned directory
+// under destDir. Upstream ships the archive flat (files at the top level, no
+// wrapper directory), so we create binDir/SwiftLM-<tag>-macos-arm64/ and
+// extract into that — giving us a stable "versioned" layout the symlink and
+// pruner can target.
 func extractTarGz(archivePath, destDir, tagName string) error {
-	if err := binaryrelease.ExtractTarGz(archivePath, destDir); err != nil {
+	versionDir := versionedDirName(tagName)
+	versionPath := filepath.Join(destDir, versionDir)
+
+	// Extract into a staging directory, then rename into place. os.Rename
+	// is atomic when source and destination live on the same volume (both
+	// under destDir here), which avoids a concurrent installer racing
+	// against a half-extracted versionPath.
+	stagePath := versionPath + ".staging"
+	if err := os.RemoveAll(stagePath); err != nil {
+		return fmt.Errorf("clear stage %s: %w", stagePath, err)
+	}
+	if err := os.MkdirAll(stagePath, 0755); err != nil {
+		return fmt.Errorf("mkdir stage %s: %w", stagePath, err)
+	}
+	defer os.RemoveAll(stagePath) // no-op after successful rename
+	if err := binaryrelease.ExtractTarGz(archivePath, stagePath); err != nil {
 		return fmt.Errorf("extract %s: %w", archivePath, err)
 	}
-	versionDir := versionedDirName(tagName)
-	info, err := os.Stat(filepath.Join(destDir, versionDir))
-	if err != nil || !info.IsDir() {
-		return fmt.Errorf("expected directory %s not found in archive", versionDir)
+	// Sanity-check the binary landed where we expect.
+	binPath := filepath.Join(stagePath, "SwiftLM")
+	if info, err := os.Stat(binPath); err != nil || info.IsDir() {
+		return fmt.Errorf("SwiftLM binary not found in archive at %s", binPath)
+	}
+	// Drop any prior install at the target so Rename succeeds on linux
+	// where rename over a non-empty dir fails with ENOTEMPTY.
+	if err := os.RemoveAll(versionPath); err != nil {
+		return fmt.Errorf("clear %s: %w", versionPath, err)
+	}
+	if err := os.Rename(stagePath, versionPath); err != nil {
+		return fmt.Errorf("activate %s: %w", versionPath, err)
 	}
 	return binaryrelease.SwapCurrentSymlink(destDir, currentLinkName, versionDir)
 }

--- a/internal/swiftlm/binary_test.go
+++ b/internal/swiftlm/binary_test.go
@@ -105,6 +105,29 @@ func TestVersionInfoRoundTrip(t *testing.T) {
 	}
 }
 
+// SaveVersionInfo must not leave a stray .tmp sibling behind on success.
+// Crash-window behavior (tmp survives a mid-write kill) is tested
+// implicitly — if a .tmp ever ends up where the real file should be, the
+// next GetInstalledVersion would reject it as unparseable.
+func TestSaveVersionInfoIsAtomic(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", oldHome)
+	os.Setenv("HOME", tmpDir)
+
+	info := &VersionInfo{TagName: "b999", BinaryPath: "/fake", InstalledAt: "now"}
+	if err := SaveVersionInfo(info); err != nil {
+		t.Fatal(err)
+	}
+	binDir := filepath.Join(tmpDir, ".lleme", "bin")
+	if _, err := os.Stat(filepath.Join(binDir, "swiftlm-version.json.tmp")); !os.IsNotExist(err) {
+		t.Errorf("leftover .tmp sibling after SaveVersionInfo: err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(binDir, "swiftlm-version.json")); err != nil {
+		t.Errorf("final version file missing: %v", err)
+	}
+}
+
 func TestPruneOldVersionsKeepsCurrentAndSymlinkTarget(t *testing.T) {
 	tmpDir := t.TempDir()
 	dirs := []string{"SwiftLM-b1-macos-arm64", "SwiftLM-b2-macos-arm64", "SwiftLM-b3-macos-arm64"}

--- a/internal/swiftlm/binary_test.go
+++ b/internal/swiftlm/binary_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nchapman/lleme/internal/binaryrelease"
 )
@@ -140,8 +141,8 @@ func TestPruneOldVersionsKeepsCurrentAndSymlinkTarget(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Prune with currentTag=b3: b1 and b2 should go.
-	pruneOldVersions(tmpDir, "b3")
+	// Prune with currentTag=b3, keepPrior=0: b1 and b2 should go.
+	pruneOldVersions(tmpDir, "b3", 0)
 
 	if _, err := os.Stat(filepath.Join(tmpDir, "SwiftLM-b3-macos-arm64")); err != nil {
 		t.Errorf("current version should survive: %v", err)
@@ -150,5 +151,60 @@ func TestPruneOldVersionsKeepsCurrentAndSymlinkTarget(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(tmpDir, d)); !os.IsNotExist(err) {
 			t.Errorf("%s should have been pruned", d)
 		}
+	}
+}
+
+// keepPrior=2 retains the two most-recent prior versions (newest first by
+// mtime) in addition to the current one. Mirrors the llama-side guarantee
+// used by auto-update to insure backends forked just before a symlink swap
+// keep the old binary on disk.
+func TestPruneOldVersionsKeepsPrior(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Create four versions and stagger mtimes so the sort order is
+	// deterministic: b4 newest, b1 oldest.
+	dirs := []string{"SwiftLM-b1-macos-arm64", "SwiftLM-b2-macos-arm64", "SwiftLM-b3-macos-arm64", "SwiftLM-b4-macos-arm64"}
+	baseTime := time.Now()
+	for i, d := range dirs {
+		p := filepath.Join(tmpDir, d)
+		if err := os.MkdirAll(p, 0755); err != nil {
+			t.Fatal(err)
+		}
+		mtime := baseTime.Add(time.Duration(i) * time.Second)
+		if err := os.Chtimes(p, mtime, mtime); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := binaryrelease.SwapCurrentSymlink(tmpDir, currentLinkName, "SwiftLM-b4-macos-arm64"); err != nil {
+		t.Fatal(err)
+	}
+
+	// currentTag=b4, keepPrior=2: b4 + b3 + b2 survive, b1 is pruned.
+	pruneOldVersions(tmpDir, "b4", 2)
+
+	for _, survivor := range []string{"SwiftLM-b2-macos-arm64", "SwiftLM-b3-macos-arm64", "SwiftLM-b4-macos-arm64"} {
+		if _, err := os.Stat(filepath.Join(tmpDir, survivor)); err != nil {
+			t.Errorf("%s should survive keepPrior=2, got err %v", survivor, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "SwiftLM-b1-macos-arm64")); !os.IsNotExist(err) {
+		t.Errorf("oldest version should have been pruned, stat err=%v", err)
+	}
+}
+
+// NewerVersionAvailable returns (nil, nil, nil) when SwiftLM has never been
+// installed — the auto-update path bootstraps nothing, only refreshes.
+func TestNewerVersionAvailableNotInstalled(t *testing.T) {
+	if !IsSupported() {
+		t.Skip("NewerVersionAvailable bootstraps from an install; unsupported platforms short-circuit to nil anyway")
+	}
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	latest, installed, err := NewerVersionAvailable()
+	if err != nil {
+		t.Fatalf("not-installed case should not error: %v", err)
+	}
+	if latest != nil || installed != nil {
+		t.Errorf("expected (nil, nil), got latest=%+v installed=%+v", latest, installed)
 	}
 }

--- a/internal/swiftlm/binary_test.go
+++ b/internal/swiftlm/binary_test.go
@@ -2,6 +2,7 @@ package swiftlm
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -188,6 +189,138 @@ func TestPruneOldVersionsKeepsPrior(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(tmpDir, "SwiftLM-b1-macos-arm64")); !os.IsNotExist(err) {
 		t.Errorf("oldest version should have been pruned, stat err=%v", err)
+	}
+}
+
+// Symlink target must survive pruning regardless of keepPrior or whether
+// the caller's currentTag matches it. Defends against partial install state
+// leaving swiftlm-current pointing at a directory that pruneOldVersions
+// would otherwise delete.
+func TestPruneRespectsSymlinkTarget(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now()
+	// b1 is oldest by mtime — would normally be pruned with keepPrior=1 and
+	// currentTag=b4. We'll point swiftlm-current at it to simulate stale
+	// state; the symlink target must survive anyway.
+	versions := []struct {
+		name  string
+		mtime time.Time
+	}{
+		{"SwiftLM-b4-macos-arm64", now},
+		{"SwiftLM-b3-macos-arm64", now.Add(-1 * time.Hour)},
+		{"SwiftLM-b2-macos-arm64", now.Add(-2 * time.Hour)},
+		{"SwiftLM-b1-macos-arm64", now.Add(-10 * time.Hour)},
+	}
+	for _, v := range versions {
+		dir := filepath.Join(tmpDir, v.name)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(dir, v.mtime, v.mtime); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink("SwiftLM-b1-macos-arm64", filepath.Join(tmpDir, currentLinkName)); err != nil {
+		t.Fatal(err)
+	}
+
+	// currentTag=b4 with keepPrior=1: normally would save b4 + b3, drop b2/b1.
+	// b1 must survive because it's the symlink target.
+	pruneOldVersions(tmpDir, "b4", 1)
+
+	if _, err := os.Stat(filepath.Join(tmpDir, "SwiftLM-b1-macos-arm64")); err != nil {
+		t.Errorf("symlink target must be retained even on mismatched currentTag: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "SwiftLM-b4-macos-arm64")); err != nil {
+		t.Errorf("currentTag directory should be retained: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "SwiftLM-b3-macos-arm64")); err != nil {
+		t.Errorf("most-recent prior should be retained with keepPrior=1: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "SwiftLM-b2-macos-arm64")); !os.IsNotExist(err) {
+		t.Errorf("b2 should be pruned with keepPrior=1: %v", err)
+	}
+}
+
+// extractTarGz must swap the swiftlm-current symlink to the newly-extracted
+// version even when a prior symlink points elsewhere. The upstream archive
+// is flat (no wrapper directory); the test mimics that shape.
+func TestExtractTarGzSwapsSymlink(t *testing.T) {
+	if _, err := exec.LookPath("tar"); err != nil {
+		t.Skip("tar not available")
+	}
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Build a flat archive containing just a stub `SwiftLM` binary.
+	srcDir := filepath.Join(tmpDir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "SwiftLM"), []byte("stub"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	archive := filepath.Join(tmpDir, "swiftlm.tar.gz")
+	if err := exec.Command("tar", "-czf", archive, "-C", srcDir, "SwiftLM").Run(); err != nil {
+		t.Fatalf("tar: %v", err)
+	}
+
+	// Pre-create an older version dir + symlink to simulate upgrade.
+	oldDir := filepath.Join(binDir, "SwiftLM-b500-macos-arm64")
+	if err := os.MkdirAll(oldDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("SwiftLM-b500-macos-arm64", filepath.Join(binDir, currentLinkName)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := extractTarGz(archive, binDir, "b600"); err != nil {
+		t.Fatalf("extractTarGz: %v", err)
+	}
+
+	target, err := os.Readlink(filepath.Join(binDir, currentLinkName))
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	if target != "SwiftLM-b600-macos-arm64" {
+		t.Errorf("symlink target = %q, want SwiftLM-b600-macos-arm64", target)
+	}
+	// Sanity: the new version dir exists and contains the stub binary.
+	if _, err := os.Stat(filepath.Join(binDir, "SwiftLM-b600-macos-arm64", "SwiftLM")); err != nil {
+		t.Errorf("extracted binary missing: %v", err)
+	}
+}
+
+// extractTarGz must reject an archive that doesn't contain the SwiftLM
+// binary where expected — a mangled upstream asset shouldn't silently swap
+// the current symlink to an unusable directory.
+func TestExtractTarGzRejectsMissingBinary(t *testing.T) {
+	if _, err := exec.LookPath("tar"); err != nil {
+		t.Skip("tar not available")
+	}
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Archive contains the wrong binary name.
+	srcDir := filepath.Join(tmpDir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "WrongName"), []byte("stub"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	archive := filepath.Join(tmpDir, "swiftlm.tar.gz")
+	if err := exec.Command("tar", "-czf", archive, "-C", srcDir, "WrongName").Run(); err != nil {
+		t.Fatalf("tar: %v", err)
+	}
+
+	if err := extractTarGz(archive, binDir, "b600"); err == nil {
+		t.Error("extractTarGz should reject archive without SwiftLM binary")
 	}
 }
 

--- a/internal/swiftlm/binary_test.go
+++ b/internal/swiftlm/binary_test.go
@@ -1,0 +1,131 @@
+package swiftlm
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nchapman/lleme/internal/binaryrelease"
+)
+
+func TestExpectedAssetName(t *testing.T) {
+	if got := expectedAssetName("b517"); got != "SwiftLM-b517-macos-arm64.tar.gz" {
+		t.Errorf("expectedAssetName = %q", got)
+	}
+}
+
+func TestFindAssetForPlatformMatches(t *testing.T) {
+	if !IsSupported() {
+		t.Skip("platform not supported")
+	}
+	rel := &binaryrelease.Release{
+		TagName: "b1",
+		Assets: []binaryrelease.Asset{
+			{Name: "SwiftLM-b1-macos-arm64.tar.gz", BrowserDownloadURL: "https://github.com/SharpAI/SwiftLM/releases/download/b1/x"},
+			{Name: "other-asset.zip", BrowserDownloadURL: "https://example.invalid/y"},
+		},
+	}
+	url, name, err := FindAssetForPlatform(rel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "SwiftLM-b1-macos-arm64.tar.gz" {
+		t.Errorf("name = %q", name)
+	}
+	if !strings.HasPrefix(url, "https://github.com/") {
+		t.Errorf("url = %q", url)
+	}
+}
+
+func TestFindAssetForPlatformMissing(t *testing.T) {
+	if !IsSupported() {
+		t.Skip("platform not supported")
+	}
+	rel := &binaryrelease.Release{
+		TagName: "b2",
+		Assets:  []binaryrelease.Asset{{Name: "wrong.tar.gz"}},
+	}
+	_, _, err := FindAssetForPlatform(rel)
+	if err == nil || !strings.Contains(err.Error(), "could not find") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestFindAssetForPlatformUnsupported(t *testing.T) {
+	if IsSupported() {
+		t.Skip("this test exercises the unsupported-platform branch")
+	}
+	_, _, err := FindAssetForPlatform(&binaryrelease.Release{TagName: "b1"})
+	if _, ok := err.(UnsupportedPlatformError); !ok {
+		t.Errorf("err = %v, want UnsupportedPlatformError", err)
+	}
+}
+
+func TestTagNameValidation(t *testing.T) {
+	good := []string{"b0", "b517", "b99999"}
+	bad := []string{"", "v1.2.3", "b", "b517-rc1", "../escape", "b517/..", "latest"}
+	for _, s := range good {
+		if !tagNameRe.MatchString(s) {
+			t.Errorf("tagNameRe should match %q", s)
+		}
+	}
+	for _, s := range bad {
+		if tagNameRe.MatchString(s) {
+			t.Errorf("tagNameRe should NOT match %q", s)
+		}
+	}
+}
+
+func TestVersionInfoRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", oldHome)
+	os.Setenv("HOME", tmpDir)
+
+	if got, err := GetInstalledVersion(); err != nil || got != nil {
+		t.Fatalf("fresh install: got %+v err %v, want nil, nil", got, err)
+	}
+
+	want := &VersionInfo{TagName: "b1", BinaryPath: "/fake/SwiftLM", InstalledAt: "2026-04-19T00:00:00Z"}
+	if err := SaveVersionInfo(want); err != nil {
+		t.Fatalf("SaveVersionInfo: %v", err)
+	}
+	got, err := GetInstalledVersion()
+	if err != nil {
+		t.Fatalf("GetInstalledVersion: %v", err)
+	}
+	if got == nil || *got != *want {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", got, want)
+	}
+
+	// File actually written where we expect.
+	if _, err := os.Stat(filepath.Join(tmpDir, ".lleme", "bin", "swiftlm-version.json")); err != nil {
+		t.Errorf("version file not at expected path: %v", err)
+	}
+}
+
+func TestPruneOldVersionsKeepsCurrentAndSymlinkTarget(t *testing.T) {
+	tmpDir := t.TempDir()
+	dirs := []string{"SwiftLM-b1-macos-arm64", "SwiftLM-b2-macos-arm64", "SwiftLM-b3-macos-arm64"}
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(tmpDir, d), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := binaryrelease.SwapCurrentSymlink(tmpDir, currentLinkName, "SwiftLM-b3-macos-arm64"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Prune with currentTag=b3: b1 and b2 should go.
+	pruneOldVersions(tmpDir, "b3")
+
+	if _, err := os.Stat(filepath.Join(tmpDir, "SwiftLM-b3-macos-arm64")); err != nil {
+		t.Errorf("current version should survive: %v", err)
+	}
+	for _, d := range []string{"SwiftLM-b1-macos-arm64", "SwiftLM-b2-macos-arm64"} {
+		if _, err := os.Stat(filepath.Join(tmpDir, d)); !os.IsNotExist(err) {
+			t.Errorf("%s should have been pruned", d)
+		}
+	}
+}

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -79,6 +79,7 @@ type Model struct {
 	// Session state
 	chatMessages         []server.ChatMessage
 	options              SessionOptions
+	sessionToggles       map[string]any // SwiftLM --thinking/--vision/--audio flags for preload
 	pendingReload        bool
 	systemPromptOverride string
 
@@ -167,6 +168,14 @@ func (m *Model) SetInitialServerOptions(ctxSize, gpuLayers, threads int, ctxSize
 	m.options.ThreadsSet = threadsSet
 }
 
+// SetSessionToggles supplies SwiftLM-specific boolean CLI flags
+// (--thinking, --vision, --audio) to layer into the preload options map.
+// Silently dropped when the resolved backend kind isn't MLX — warning the
+// user mid-render would corrupt the TUI.
+func (m *Model) SetSessionToggles(toggles map[string]any) {
+	m.sessionToggles = toggles
+}
+
 // SetSamplingOptions sets the sampling options from CLI flags
 func (m *Model) SetSamplingOptions(temp, topP, minP, repeatPenalty, presencePenalty, frequencyPenalty float64, topK, maxTokens int) {
 	m.options.Temp = temp
@@ -207,6 +216,17 @@ func (m *Model) preloadModel() tea.Cmd {
 		personaOpts = m.persona.GetServerOptions(kind)
 	}
 	mergedOpts := presets.MergeServerOptions(m.preset, personaOpts, kind)
+	// Layer CLI toggle flags on top; only for MLX (where they're meaningful).
+	// llama.cpp callers see a warning on stdout from the cmd-level helper
+	// before the TUI takes over; here we drop silently.
+	if kind == hf.BackendMLX && len(m.sessionToggles) > 0 {
+		if mergedOpts == nil {
+			mergedOpts = make(map[string]any)
+		}
+		for k, v := range m.sessionToggles {
+			mergedOpts[k] = v
+		}
+	}
 
 	return func() tea.Msg {
 		var opts *server.RunOptions

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -134,7 +134,7 @@ func New(api *server.APIClient, modelName string, cfg *config.Config, persona *c
 		persona:     persona,
 		preset:      preset,
 		personaName: personaName,
-		resolver:    options.NewResolver(persona, cfg, preset),
+		resolver:    options.NewResolver(persona, cfg, preset).WithBackendKind(hf.BackendKindForModelName(modelName)),
 
 		chatMessages: []server.ChatMessage{},
 		keys:         DefaultKeyMap(),

--- a/internal/tui/chat/chat.go
+++ b/internal/tui/chat/chat.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/nchapman/lleme/internal/config"
+	"github.com/nchapman/lleme/internal/hf"
 	"github.com/nchapman/lleme/internal/options"
 	"github.com/nchapman/lleme/internal/presets"
 	"github.com/nchapman/lleme/internal/server"
@@ -200,11 +201,12 @@ func (m *Model) preloadModel() tea.Cmd {
 	api := m.api
 	model := m.model
 	options := m.options
+	kind := hf.BackendKindForModelName(m.model)
 	var personaOpts map[string]any
 	if m.persona != nil {
-		personaOpts = m.persona.GetServerOptions()
+		personaOpts = m.persona.GetServerOptions(kind)
 	}
-	mergedOpts := presets.MergeServerOptions(m.preset, personaOpts)
+	mergedOpts := presets.MergeServerOptions(m.preset, personaOpts, kind)
 
 	return func() tea.Msg {
 		var opts *server.RunOptions

--- a/internal/tui/chat/commands.go
+++ b/internal/tui/chat/commands.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/nchapman/lleme/internal/hf"
 	"github.com/nchapman/lleme/internal/presets"
 	"github.com/nchapman/lleme/internal/server"
 	"github.com/nchapman/lleme/internal/tui/components"
@@ -136,12 +137,13 @@ func (m *Model) handleReload() CommandResultMsg {
 		return CommandResultMsg{Message: fmt.Sprintf("Failed to stop model: %v", err), IsError: true}
 	}
 
+	kind := hf.BackendKindForModelName(m.model)
 	var personaOpts map[string]any
 	if m.persona != nil {
-		personaOpts = m.persona.GetServerOptions()
+		personaOpts = m.persona.GetServerOptions(kind)
 	}
 	opts := &server.RunOptions{
-		Options: presets.MergeServerOptions(m.preset, personaOpts),
+		Options: presets.MergeServerOptions(m.preset, personaOpts, kind),
 	}
 	if m.options.CtxSizeSet {
 		opts.CtxSize = server.IntPtr(m.options.CtxSize)

--- a/internal/ui/style.go
+++ b/internal/ui/style.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/nchapman/lleme/internal/styles"
@@ -60,6 +61,30 @@ func Keyword(text string) string {
 // LlamaCppCredit returns the llama.cpp attribution line.
 func LlamaCppCredit(version string) string {
 	return Muted(fmt.Sprintf("Powered by llama.cpp %s", version))
+}
+
+// SwiftLMCredit returns the SwiftLM attribution line.
+func SwiftLMCredit(version string) string {
+	return Muted(fmt.Sprintf("Powered by SwiftLM %s", version))
+}
+
+// BackendsCredit returns a combined attribution line for whichever backends
+// are installed. Empty version strings are omitted so we never show a
+// "Powered by llama.cpp " with no tag on hosts where the backend isn't
+// present. Separator is a middle dot for visual parity with the rest of
+// the status lines.
+func BackendsCredit(llamaVersion, swiftLMVersion string) string {
+	var parts []string
+	if llamaVersion != "" {
+		parts = append(parts, fmt.Sprintf("llama.cpp %s", llamaVersion))
+	}
+	if swiftLMVersion != "" {
+		parts = append(parts, fmt.Sprintf("SwiftLM %s", swiftLMVersion))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return Muted("Powered by " + strings.Join(parts, " • "))
 }
 
 // Fatal prints an error message to stderr and exits with code 1.

--- a/internal/ui/style_test.go
+++ b/internal/ui/style_test.go
@@ -74,6 +74,51 @@ func TestLlamaCppCredit(t *testing.T) {
 	}
 }
 
+func TestSwiftLMCredit(t *testing.T) {
+	result := SwiftLMCredit("b517")
+	if !strings.Contains(result, "SwiftLM") || !strings.Contains(result, "b517") {
+		t.Errorf("SwiftLMCredit = %q, want to include SwiftLM and version", result)
+	}
+}
+
+func TestBackendsCredit(t *testing.T) {
+	tests := []struct {
+		name       string
+		llama      string
+		swiftlm    string
+		wantEmpty  bool
+		wantSubstr []string
+	}{
+		{name: "both tags", llama: "b1234", swiftlm: "b517", wantSubstr: []string{"llama.cpp b1234", "SwiftLM b517", "•"}},
+		{name: "llama only", llama: "b1234", wantSubstr: []string{"llama.cpp b1234"}},
+		{name: "swiftlm only", swiftlm: "b517", wantSubstr: []string{"SwiftLM b517"}},
+		{name: "neither", wantEmpty: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BackendsCredit(tt.llama, tt.swiftlm)
+			if tt.wantEmpty {
+				if got != "" {
+					t.Errorf("BackendsCredit() = %q, want empty", got)
+				}
+				return
+			}
+			for _, s := range tt.wantSubstr {
+				if !strings.Contains(got, s) {
+					t.Errorf("BackendsCredit() = %q, want to contain %q", got, s)
+				}
+			}
+			// Never print a naked "llama.cpp " or "SwiftLM " with no tag.
+			if tt.llama == "" && strings.Contains(got, "llama.cpp") {
+				t.Errorf("should omit llama.cpp when empty tag: %q", got)
+			}
+			if tt.swiftlm == "" && strings.Contains(got, "SwiftLM") {
+				t.Errorf("should omit SwiftLM when empty tag: %q", got)
+			}
+		})
+	}
+}
+
 func TestIconConstants(t *testing.T) {
 	if IconCheck == "" {
 		t.Error("Expected IconCheck to be non-empty")


### PR DESCRIPTION
## Summary

This branch takes lleme from GGUF-only to GGUF + MLX served through a single proxy, adds a native Anthropic `/v1/messages` surface, hardens the install/download paths, and closes the backend-parity gaps the recent audit surfaced. Thirty commits, broadly in three phases.

### MLX end-to-end
- `internal/proxy/` gains a `Runtime` interface; `SwiftLMRuntime` wires MLX models (darwin/arm64 only) to the SwiftLM server alongside `LlamaRuntime`.
- `internal/swiftlm/` installs + manages the SwiftLM binary via shared primitives in `internal/binaryrelease/`.
- Per-repo `metadata.yaml` records backend kind per quant; `hf.PullMLXModel` downloads tokenizer + safetensors trees into a per-quant directory.
- Presets + personas support backend-scoped `llamacpp:` / `swiftlm:` sub-blocks on top of shared `options:`.

### Anthropic `/v1/messages` translation
- In-proxy conversion to `/v1/chat/completions` so backends only speak OpenAI.
- Full tool-use round-trip (request, response, streaming), image base64 handling, stop-sequence forwarding, error-type normalization, periodic SSE ping frames (nginx-safe), and reasoning/thinking passthrough keyed on DeepSeek-convention `reasoning_content` (llama-server `--reasoning-format`, SwiftLM `--thinking`).
- Input-side `thinking` blocks in prior assistant turns are concatenated into `reasoning_content` on the upstream message to match llama.cpp's native `/v1/messages` translator.

### Security hardening
- Shared safe-tar extractor + path-traversal guard in `internal/binaryrelease/`.
- HuggingFace redirect allow-list + per-file size cap in `internal/hf/client.go`.
- Tag-name validation, atomic symlink swap, and atomic `version.json` writes.
- Per-request body cap on proxy endpoints.

### Backend parity (follow-up audit)
Two real bugs and a set of UX gaps where llama.cpp had features SwiftLM lacked:
- **Critical:** orphan SwiftLM cleanup on proxy crash; `options.Resolver` reads the correct backend's config block.
- SwiftLM auto-update (CLI `update swiftlm`, background refresh, `auto_update` config knob), needs-based backend install on `server start` / `run`, `SwiftLM` line in `version` / `status` / `serve` footer, `--thinking/--vision/--audio` flags on `run`.
- MLX re-pull freshness check (manifest + size fallback), `IsStartupError` covers the Swift runtime's actual abort shapes, unknown SwiftLM option keys logged, corrupt-metadata `BackendKindForModelName` fallback logged.
- Dead `LlamaCpp.ServerPath` removed; template-patching gap on SwiftLM documented as deferred.

## Test plan

- [x] `make check` green on every commit (fmt, vet, full test suite, golangci-lint).
- [x] Unit coverage for: Anthropic request / response / streaming translation (happy, thinking, tool_use, stop_sequence, image + url rejection, error shapes); options resolver backend scoping; MLX manifest round-trip + drift; SwiftLM symlink + extract atomicity; orphan-process matcher (llama + SwiftLM + false-positive `MySwiftLMWrapper`); startup-error marker coverage for Swift runtime failure shapes.
- [ ] Manual integration on darwin/arm64:
  - [ ] Pull one GGUF + one MLX model; `list` and `remove` handle both.
  - [ ] Kill `lleme serve` mid-session with SwiftLM backend loaded; restart; confirm no orphan SwiftLM process.
  - [ ] Set `swiftlm.options.temp` in `~/.lleme/config.yaml`; confirm TUI reports it on an MLX session.
  - [ ] `lleme update` prints both backends; `lleme update swiftlm` updates only SwiftLM.
  - [ ] Fresh host with only an MLX model pulled → `lleme serve` does not download llama.cpp.
  - [ ] Re-run `lleme pull <mlx-model>` on an up-to-date model → "already up to date", no byte transfer.
  - [ ] Claude Code pointed at the proxy with a reasoning model → thinking panel renders `thinking_delta` events.
- [ ] Manual smoke on Linux: `update`, `serve`, `version` all work; SwiftLM paths no-op silently.