### PR TITLE
feat(proxy): normalize backend OpenAI responses

### DIFF
--- a/internal/proxy/normalize/buffered.go
+++ b/internal/proxy/normalize/buffered.go
@@ -3,8 +3,15 @@ package normalize
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 )
+
+// ErrResponseTooLarge is returned when a backend response body exceeds
+// maxBufferedResponseBytes. Surfaced rather than silently truncated so
+// the caller can return a clear error instead of a corrupt payload.
+var ErrResponseTooLarge = errors.New("normalize: backend response exceeded size cap")
 
 // maxBufferedResponseBytes caps the size of a non-streaming backend
 // response body the proxy will buffer in memory. A misbehaving or
@@ -41,9 +48,15 @@ func (b *bufferedReader) Read(p []byte) (int, error) {
 
 func (b *bufferedReader) load() error {
 	b.loaded = true
-	body, err := io.ReadAll(io.LimitReader(b.upstream, maxBufferedResponseBytes))
+	// Read one byte past the cap so we can detect overflow. Plain
+	// io.LimitReader silently truncates, which would yield a partial
+	// (likely invalid) JSON body served with a 200 status.
+	body, err := io.ReadAll(io.LimitReader(b.upstream, maxBufferedResponseBytes+1))
 	if err != nil {
 		return err
+	}
+	if len(body) > maxBufferedResponseBytes {
+		return fmt.Errorf("%w (limit: %d bytes)", ErrResponseTooLarge, maxBufferedResponseBytes)
 	}
 	b.buf = bytes.NewReader(normalizeResponseBody(body, b.opts))
 	return nil

--- a/internal/proxy/normalize/buffered.go
+++ b/internal/proxy/normalize/buffered.go
@@ -1,0 +1,67 @@
+package normalize
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// maxBufferedResponseBytes caps the size of a non-streaming backend
+// response body the proxy will buffer in memory. A misbehaving or
+// adversarial backend that returns a multi-GB body would otherwise
+// OOM the proxy. 64 MiB comfortably exceeds any realistic single
+// chat-completion JSON (long conversations stream; non-stream
+// responses with reasoning + tool calls top out around 1-2 MiB in
+// practice).
+const maxBufferedResponseBytes = 64 * 1024 * 1024
+
+// bufferedReader handles non-streaming /v1/chat/completions responses.
+// Reads the full body once on first Read (capped via io.LimitReader),
+// runs response normalizers on the parsed top-level object,
+// re-marshals, then serves bytes from an internal buffer.
+type bufferedReader struct {
+	upstream io.Reader
+	opts     Options
+	buf      *bytes.Reader
+	loaded   bool
+}
+
+func newBufferedReader(r io.Reader, opts Options) *bufferedReader {
+	return &bufferedReader{upstream: r, opts: opts}
+}
+
+func (b *bufferedReader) Read(p []byte) (int, error) {
+	if !b.loaded {
+		if err := b.load(); err != nil {
+			return 0, err
+		}
+	}
+	return b.buf.Read(p)
+}
+
+func (b *bufferedReader) load() error {
+	b.loaded = true
+	body, err := io.ReadAll(io.LimitReader(b.upstream, maxBufferedResponseBytes))
+	if err != nil {
+		return err
+	}
+	b.buf = bytes.NewReader(normalizeResponseBody(body, b.opts))
+	return nil
+}
+
+// normalizeResponseBody parses, transforms, and re-marshals a JSON
+// response body. Returns the original bytes unchanged if parsing or
+// re-marshaling fails — better to ship the upstream's body verbatim
+// than to return a mangled response.
+func normalizeResponseBody(body []byte, opts Options) []byte {
+	var obj chunkObject
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return body
+	}
+	applyResponseNormalizers(obj, opts)
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return body
+	}
+	return out
+}

--- a/internal/proxy/normalize/buffered_test.go
+++ b/internal/proxy/normalize/buffered_test.go
@@ -2,6 +2,7 @@ package normalize
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -93,24 +94,24 @@ func TestWrapDispatch(t *testing.T) {
 	})
 }
 
-// TestBufferedRespectsResponseSizeCap — verifies the io.LimitReader
-// guard against a backend returning an oversized non-streaming
-// response. Without the cap, io.ReadAll would buffer indefinitely.
-// We don't try to assert a specific byte count post-cap; just that
-// the loader returns without consuming the entire infinite source.
+// TestBufferedRespectsResponseSizeCap — verifies the size-cap guard
+// against a backend returning an oversized non-streaming response.
+// Without the cap, io.ReadAll would buffer indefinitely. The loader
+// must surface ErrResponseTooLarge instead of silently truncating
+// (which would yield a partial/invalid JSON body served as 200).
 func TestBufferedRespectsResponseSizeCap(t *testing.T) {
-	// infiniteReader yields 'x' forever — io.ReadAll without a cap
-	// would never return.
 	r := newBufferedReader(infiniteReader{}, Options{})
-	done := make(chan struct{})
+	done := make(chan error, 1)
 	go func() {
-		_, _ = io.ReadAll(r)
-		close(done)
+		_, err := io.ReadAll(r)
+		done <- err
 	}()
 	select {
-	case <-done:
-		// load() returned: cap worked.
-	case <-time.After(2 * time.Second):
+	case err := <-done:
+		if !errors.Is(err, ErrResponseTooLarge) {
+			t.Fatalf("expected ErrResponseTooLarge, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
 		t.Fatal("buffered loader did not honor size cap (infinite read)")
 	}
 }

--- a/internal/proxy/normalize/buffered_test.go
+++ b/internal/proxy/normalize/buffered_test.go
@@ -1,0 +1,139 @@
+package normalize
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBufferedNormalizesNonStreamResponse(t *testing.T) {
+	// Minimal SwiftLM-shaped non-streaming response: model is the
+	// backend's internal id, no system_fingerprint, usage missing
+	// details. All three should be patched.
+	in := `{"id":"chatcmpl-1","object":"chat.completion","model":"backend-id","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}`
+	r := newBufferedReader(strings.NewReader(in), Options{
+		RequestedModel: "user/repo",
+		Fingerprint:    "lleme-test",
+	})
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v\nbody=%s", err, out)
+	}
+	if got["model"] != "user/repo" {
+		t.Errorf("model = %v, want user/repo", got["model"])
+	}
+	if got["system_fingerprint"] != "lleme-test" {
+		t.Errorf("system_fingerprint = %v, want lleme-test", got["system_fingerprint"])
+	}
+	usage := got["usage"].(map[string]any)
+	if _, ok := usage["prompt_tokens_details"]; !ok {
+		t.Errorf("prompt_tokens_details missing")
+	}
+	if _, ok := usage["completion_tokens_details"]; !ok {
+		t.Errorf("completion_tokens_details missing")
+	}
+}
+
+// TestWrapDispatch verifies the public Wrap entrypoint: streaming
+// option picks the SSE-aware reader, non-streaming picks the buffered
+// JSON reader, and the empty Fingerprint default is applied. The
+// internal constructors are exercised everywhere else; this test
+// pins down the public API surface.
+func TestWrapDispatch(t *testing.T) {
+	t.Run("streaming dispatches to stream reader", func(t *testing.T) {
+		// A complete SSE frame survives the stream reader and gets its
+		// model rewritten. The buffered reader would have JSON-parsed
+		// the entire body (including the SSE framing) and produced
+		// nonsense — observable difference confirms dispatch.
+		in := "data: {\"object\":\"chat.completion.chunk\",\"model\":\"backend\"}\n\n"
+		got, err := io.ReadAll(Wrap(strings.NewReader(in), Options{
+			Streaming:      true,
+			RequestedModel: "user/repo",
+			Fingerprint:    "lleme-test",
+		}))
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if !strings.Contains(string(got), `"model":"user/repo"`) {
+			t.Errorf("streaming wrap did not rewrite model: %s", got)
+		}
+		if !strings.HasSuffix(string(got), "\n\n") {
+			t.Errorf("streaming wrap dropped SSE frame terminator: %q", got)
+		}
+	})
+
+	t.Run("non-streaming dispatches to buffered reader", func(t *testing.T) {
+		// Buffered reader will parse JSON and rewrite model. The
+		// streaming reader would not (no data: line).
+		in := `{"model":"backend"}`
+		out, err := io.ReadAll(Wrap(strings.NewReader(in), Options{RequestedModel: "user/repo"}))
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if !strings.Contains(string(out), `"model":"user/repo"`) {
+			t.Errorf("buffered wrap did not rewrite model: %s", out)
+		}
+	})
+
+	t.Run("empty fingerprint defaults to lleme-dev", func(t *testing.T) {
+		in := `{}`
+		out, err := io.ReadAll(Wrap(strings.NewReader(in), Options{}))
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if !strings.Contains(string(out), `"system_fingerprint":"lleme-dev"`) {
+			t.Errorf("default fingerprint not applied: %s", out)
+		}
+	})
+}
+
+// TestBufferedRespectsResponseSizeCap — verifies the io.LimitReader
+// guard against a backend returning an oversized non-streaming
+// response. Without the cap, io.ReadAll would buffer indefinitely.
+// We don't try to assert a specific byte count post-cap; just that
+// the loader returns without consuming the entire infinite source.
+func TestBufferedRespectsResponseSizeCap(t *testing.T) {
+	// infiniteReader yields 'x' forever — io.ReadAll without a cap
+	// would never return.
+	r := newBufferedReader(infiniteReader{}, Options{})
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.ReadAll(r)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// load() returned: cap worked.
+	case <-time.After(2 * time.Second):
+		t.Fatal("buffered loader did not honor size cap (infinite read)")
+	}
+}
+
+type infiniteReader struct{}
+
+func (infiniteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'x'
+	}
+	return len(p), nil
+}
+
+func TestBufferedPassesMalformedJSON(t *testing.T) {
+	// Defensive posture: never replace the upstream body with a parse
+	// error. Better to ship the original bytes than a mangled response.
+	in := "not json at all"
+	r := newBufferedReader(strings.NewReader(in), Options{RequestedModel: "x", Fingerprint: "y"})
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(out) != in {
+		t.Errorf("malformed body changed: got %q, want %q", out, in)
+	}
+}

--- a/internal/proxy/normalize/normalize.go
+++ b/internal/proxy/normalize/normalize.go
@@ -1,0 +1,53 @@
+// Package normalize patches subtle divergences in backend OpenAI surfaces
+// (llama-server, SwiftLM) into a single canonical shape before responses
+// reach OpenAI clients or the in-proxy Anthropic translator.
+//
+// Design rules — all four normalizers obey these:
+//
+//   - Idempotent: running a second pass on already-normalized output is a
+//     no-op. Tests assert this directly so we don't drift.
+//   - Self-disabling: when a backend stops emitting the bad pattern (e.g.
+//     SwiftLM lands its prefill_progress filtering, or starts populating
+//     system_fingerprint), the normalizer sees the new shape, finds no
+//     work to do, and passes the bytes through. We never have to remove
+//     a normalizer just because upstream caught up.
+//   - Additive only: never overwrite a field the backend provided. The
+//     single exception is `model`, which we always rewrite to the name
+//     the client requested — that's the contract callers depend on.
+//
+// Frames the normalizer can't parse (malformed JSON, unrecognized SSE
+// shapes) pass through verbatim. The proxy mirrors the Anthropic
+// translator's posture: never abort a stream over one bad chunk.
+package normalize
+
+import (
+	"io"
+)
+
+// Options configures a Wrap. RequestedModel is the model name from the
+// client's request — we rewrite responses to echo it back, since SwiftLM
+// substitutes its own internal modelId. Streaming switches between the
+// SSE-aware reader and the buffered JSON reader.
+type Options struct {
+	RequestedModel string
+	Streaming      bool
+	// Fingerprint is the value injected into responses when the backend
+	// omits system_fingerprint. Defaults to "lleme-dev" if empty.
+	Fingerprint string
+}
+
+// Wrap returns an io.Reader that yields normalized bytes. The wrapper
+// does not own the upstream's lifecycle: the caller is responsible for
+// closing the original response body. Returning io.Reader (not
+// io.ReadCloser) keeps that ownership boundary explicit and lets
+// callers keep their existing `defer resp.Body.Close()` patterns
+// without risking double-close.
+func Wrap(r io.Reader, opts Options) io.Reader {
+	if opts.Fingerprint == "" {
+		opts.Fingerprint = "lleme-dev"
+	}
+	if opts.Streaming {
+		return newStreamReader(r, opts)
+	}
+	return newBufferedReader(r, opts)
+}

--- a/internal/proxy/normalize/normalizers.go
+++ b/internal/proxy/normalize/normalizers.go
@@ -1,0 +1,136 @@
+package normalize
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// chunkObject is the parsed top-level of one OpenAI response or SSE
+// chunk, kept as a map so unknown fields round-trip untouched. Every
+// normalizer mutates this map; the caller re-marshals at the end. Using
+// json.RawMessage for values means we never touch nested structure we
+// don't have an opinion on.
+type chunkObject map[string]json.RawMessage
+
+// applyChunkNormalizers runs all per-chunk passes against an SSE frame's
+// parsed payload. Returns false if the frame should be dropped entirely
+// (currently only prefill_progress triggers this).
+//
+// Order matters only for prefill-filter (cheapest, may short-circuit);
+// the rest are commutative.
+func applyChunkNormalizers(obj chunkObject, opts Options) (keep bool) {
+	if !filterPrefillProgress(obj) {
+		return false
+	}
+	rewriteModel(obj, opts.RequestedModel)
+	synthesizeFingerprint(obj, opts.Fingerprint)
+	synthesizeUsageDetails(obj)
+	return true
+}
+
+// applyResponseNormalizers runs the non-streaming variants. No prefill
+// filter — that's a stream-only artifact.
+func applyResponseNormalizers(obj chunkObject, opts Options) {
+	rewriteModel(obj, opts.RequestedModel)
+	synthesizeFingerprint(obj, opts.Fingerprint)
+	synthesizeUsageDetails(obj)
+}
+
+// filterPrefillProgress returns false when the chunk's "object" is
+// "prefill_progress" — SwiftLM's non-OpenAI heartbeat frame emitted
+// during prompt processing. Strict OpenAI clients reject it. Returns
+// true for every other shape (passthrough).
+//
+// Self-disabling: if SwiftLM stops emitting these, we never see the
+// triggering object value.
+func filterPrefillProgress(obj chunkObject) bool {
+	raw, ok := obj["object"]
+	if !ok {
+		return true
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return true
+	}
+	return s != "prefill_progress"
+}
+
+// rewriteModel always sets "model" to the requested name. SwiftLM
+// substitutes its internal modelId; llama-server already echoes the
+// request, so this is a no-op there. Empty requested model leaves the
+// field alone — happens when callers don't care (Anthropic path).
+//
+// This is the one normalizer that overwrites; the contract is that the
+// response model name matches the request.
+func rewriteModel(obj chunkObject, model string) {
+	if model == "" {
+		return
+	}
+	encoded, err := json.Marshal(model)
+	if err != nil {
+		return
+	}
+	obj["model"] = encoded
+}
+
+// synthesizeFingerprint inserts a stable system_fingerprint when the
+// backend omits one (or sends null). Strict OpenAI SDK consumers expect
+// the field to be present and non-null. The value isn't load-bearing —
+// presence is.
+//
+// Additive: never overwrites a backend-supplied string.
+func synthesizeFingerprint(obj chunkObject, fingerprint string) {
+	if raw, ok := obj["system_fingerprint"]; ok && !isJSONNull(raw) {
+		return
+	}
+	encoded, err := json.Marshal(fingerprint)
+	if err != nil {
+		return
+	}
+	obj["system_fingerprint"] = encoded
+}
+
+// synthesizeUsageDetails fills in prompt_tokens_details and
+// completion_tokens_details on the embedded usage block when missing.
+// SwiftLM's TokenUsage struct only carries the three core counts;
+// llama-server emits cached_tokens. Zero defaults are honest for
+// SwiftLM — it has no prompt cache and no separate reasoning-token
+// bucket.
+//
+// No-op when "usage" is absent (typical streaming chunks). Additive
+// per-key: if backend supplies one details block but not the other,
+// the missing one is filled and the present one is left alone.
+func synthesizeUsageDetails(obj chunkObject) {
+	raw, ok := obj["usage"]
+	if !ok || isJSONNull(raw) {
+		return
+	}
+	var usage chunkObject
+	if err := json.Unmarshal(raw, &usage); err != nil {
+		return
+	}
+	changed := false
+	if _, has := usage["prompt_tokens_details"]; !has {
+		usage["prompt_tokens_details"] = json.RawMessage(`{"cached_tokens":0}`)
+		changed = true
+	}
+	if _, has := usage["completion_tokens_details"]; !has {
+		usage["completion_tokens_details"] = json.RawMessage(`{"reasoning_tokens":0}`)
+		changed = true
+	}
+	if !changed {
+		return
+	}
+	encoded, err := json.Marshal(usage)
+	if err != nil {
+		return
+	}
+	obj["usage"] = encoded
+}
+
+// isJSONNull reports whether a raw value is the JSON literal null. Used
+// so absent and explicit-null are treated identically by the synthesis
+// passes — both mean "backend didn't give us a value, supply one."
+func isJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}

--- a/internal/proxy/normalize/normalizers_test.go
+++ b/internal/proxy/normalize/normalizers_test.go
@@ -1,0 +1,208 @@
+package normalize
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// parse is a test helper that round-trips a JSON string through
+// chunkObject so tests can build inputs as readable JSON literals
+// rather than constructing maps by hand.
+func parse(t *testing.T, s string) chunkObject {
+	t.Helper()
+	var obj chunkObject
+	if err := json.Unmarshal([]byte(s), &obj); err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return obj
+}
+
+func encode(t *testing.T, obj chunkObject) string {
+	t.Helper()
+	out, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return string(out)
+}
+
+func TestFilterPrefillProgress(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		keep bool
+	}{
+		{"chat.completion.chunk passthrough", `{"object":"chat.completion.chunk"}`, true},
+		{"chat.completion passthrough", `{"object":"chat.completion"}`, true},
+		{"prefill_progress dropped", `{"object":"prefill_progress","fraction":0.5}`, false},
+		{"missing object passthrough", `{"id":"x"}`, true},
+		{"non-string object passthrough", `{"object":42}`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterPrefillProgress(parse(t, tt.in))
+			if got != tt.keep {
+				t.Errorf("filterPrefillProgress(%s) = %v, want %v", tt.in, got, tt.keep)
+			}
+		})
+	}
+}
+
+func TestRewriteModel(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		requested string
+		wantModel string
+	}{
+		{"swap", `{"model":"backend-internal-id"}`, "user/repo", "user/repo"},
+		{"already matches", `{"model":"user/repo"}`, "user/repo", "user/repo"},
+		{"absent gets inserted", `{}`, "user/repo", "user/repo"},
+		{"empty requested leaves untouched", `{"model":"x"}`, "", "x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := parse(t, tt.in)
+			rewriteModel(obj, tt.requested)
+			var got string
+			if raw, ok := obj["model"]; ok {
+				_ = json.Unmarshal(raw, &got)
+			}
+			if got != tt.wantModel {
+				t.Errorf("model = %q, want %q", got, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestSynthesizeFingerprint(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string // empty = expect inserted "test-fp"
+	}{
+		{"absent", `{}`, "test-fp"},
+		{"explicit null", `{"system_fingerprint":null}`, "test-fp"},
+		{"present preserved", `{"system_fingerprint":"backend-supplied"}`, "backend-supplied"},
+		{"empty string preserved", `{"system_fingerprint":""}`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := parse(t, tt.in)
+			synthesizeFingerprint(obj, "test-fp")
+			var got string
+			_ = json.Unmarshal(obj["system_fingerprint"], &got)
+			if got != tt.want {
+				t.Errorf("system_fingerprint = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSynthesizeUsageDetails(t *testing.T) {
+	tests := []struct {
+		name           string
+		in             string
+		wantPromptDet  string
+		wantComplDet   string
+		expectNoChange bool
+	}{
+		{
+			name:           "no usage block",
+			in:             `{}`,
+			expectNoChange: true,
+		},
+		{
+			name:           "explicit null usage",
+			in:             `{"usage":null}`,
+			expectNoChange: true,
+		},
+		{
+			name:          "neither details key",
+			in:            `{"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+			wantPromptDet: `{"cached_tokens":0}`,
+			wantComplDet:  `{"reasoning_tokens":0}`,
+		},
+		{
+			name:          "prompt details supplied, completion missing",
+			in:            `{"usage":{"prompt_tokens":10,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":4}}}`,
+			wantPromptDet: `{"cached_tokens":4}`,
+			wantComplDet:  `{"reasoning_tokens":0}`,
+		},
+		{
+			name:          "both supplied — no overwrite",
+			in:            `{"usage":{"prompt_tokens":10,"prompt_tokens_details":{"cached_tokens":7},"completion_tokens_details":{"reasoning_tokens":3}}}`,
+			wantPromptDet: `{"cached_tokens":7}`,
+			wantComplDet:  `{"reasoning_tokens":3}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := parse(t, tt.in)
+			before := encode(t, obj)
+			synthesizeUsageDetails(obj)
+			after := encode(t, obj)
+			if tt.expectNoChange {
+				if before != after {
+					t.Errorf("expected no change; before=%s after=%s", before, after)
+				}
+				return
+			}
+			var usage chunkObject
+			_ = json.Unmarshal(obj["usage"], &usage)
+			if got := string(usage["prompt_tokens_details"]); got != tt.wantPromptDet {
+				t.Errorf("prompt_tokens_details = %s, want %s", got, tt.wantPromptDet)
+			}
+			if got := string(usage["completion_tokens_details"]); got != tt.wantComplDet {
+				t.Errorf("completion_tokens_details = %s, want %s", got, tt.wantComplDet)
+			}
+		})
+	}
+}
+
+// TestApplyChunkNormalizersIdempotent verifies the headline design
+// promise: feeding normalized output back through produces no further
+// changes. If this ever fails we've introduced a destructive pass.
+func TestApplyChunkNormalizersIdempotent(t *testing.T) {
+	inputs := []string{
+		`{"object":"chat.completion.chunk","model":"backend-id","choices":[]}`,
+		`{"object":"chat.completion.chunk","model":"backend-id","usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`,
+		`{"object":"chat.completion","model":"backend-id","system_fingerprint":"existing","usage":{"prompt_tokens":1}}`,
+	}
+	opts := Options{RequestedModel: "user/repo", Fingerprint: "lleme-test"}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			first := parse(t, in)
+			if !applyChunkNormalizers(first, opts) {
+				t.Fatalf("first pass dropped frame unexpectedly")
+			}
+			firstOut := encode(t, first)
+
+			second := parse(t, firstOut)
+			if !applyChunkNormalizers(second, opts) {
+				t.Fatalf("second pass dropped frame unexpectedly")
+			}
+			secondOut := encode(t, second)
+
+			if firstOut != secondOut {
+				t.Errorf("not idempotent:\nfirst:  %s\nsecond: %s", firstOut, secondOut)
+			}
+		})
+	}
+}
+
+// TestApplyChunkNormalizersAdditive proves we never overwrite a
+// backend-supplied system_fingerprint or details block. This is the
+// "if backends fix their problems, it just works" guarantee.
+func TestApplyChunkNormalizersAdditive(t *testing.T) {
+	in := `{"object":"chat.completion","model":"x","system_fingerprint":"backend-fp","usage":{"prompt_tokens":1,"prompt_tokens_details":{"cached_tokens":42},"completion_tokens_details":{"reasoning_tokens":7}}}`
+	obj := parse(t, in)
+	applyChunkNormalizers(obj, Options{RequestedModel: "user/repo", Fingerprint: "lleme-test"})
+	out := encode(t, obj)
+	for _, mustContain := range []string{`"backend-fp"`, `"cached_tokens":42`, `"reasoning_tokens":7`} {
+		if !strings.Contains(out, mustContain) {
+			t.Errorf("backend value lost; output=%s want contains %s", out, mustContain)
+		}
+	}
+}

--- a/internal/proxy/normalize/stream.go
+++ b/internal/proxy/normalize/stream.go
@@ -58,15 +58,21 @@ func (s *streamReader) Read(p []byte) (int, error) {
 	return s.out.Read(p)
 }
 
-// Frame-buffer caps. A misbehaving backend that emits a single
-// multi-GB line, or an event with a runaway number of lines, would
-// otherwise grow our per-frame buffer without bound. The numbers are
-// generous against real traffic — a long reasoning trace or a tool
-// call with a serialized 1 MiB JSON argument blob still fits — but
-// finite enough to keep one bad backend from killing the proxy.
+// Frame-buffer caps. Three independent bounds — per-line, per-frame
+// total bytes, and per-frame line count — keep one bad backend from
+// killing the proxy regardless of which dimension it abuses. Without
+// the per-frame total, a runaway backend could pack many near-max
+// lines into one frame and consume far more than maxStreamLineBytes.
+//
+// Numbers are generous against real traffic: a single chat-completion
+// chunk with a long reasoning trace or a serialized 1 MiB tool-call
+// argument blob fits in maxStreamLineBytes; backends emit ~1-3 lines
+// per frame in practice (data: + maybe id:/event:), well under
+// maxStreamFrameLines.
 const (
-	maxStreamLineBytes  = 8 * 1024 * 1024
-	maxStreamFrameLines = 1024
+	maxStreamLineBytes  = 8 * 1024 * 1024  // single line cap
+	maxStreamFrameBytes = 16 * 1024 * 1024 // total bytes across all lines in a frame
+	maxStreamFrameLines = 128              // line count
 )
 
 // pumpFrame reads one SSE frame from upstream, normalizes it, and
@@ -89,6 +95,7 @@ const (
 // JSON payload would corrupt downstream parsing.
 func (s *streamReader) pumpFrame() error {
 	var lines [][]byte
+	frameBytes := 0
 	sawAnyLine := false
 	for {
 		line, err := readLineCapped(s.reader, maxStreamLineBytes)
@@ -99,8 +106,12 @@ func (s *streamReader) pumpFrame() error {
 				return s.emitFrame(lines)
 			}
 			lines = append(lines, line)
+			frameBytes += len(line)
 			if len(lines) > maxStreamFrameLines {
 				return fmt.Errorf("normalize: SSE frame exceeded %d lines", maxStreamFrameLines)
+			}
+			if frameBytes > maxStreamFrameBytes {
+				return fmt.Errorf("normalize: SSE frame exceeded %d bytes", maxStreamFrameBytes)
 			}
 		}
 		if err == io.EOF {

--- a/internal/proxy/normalize/stream.go
+++ b/internal/proxy/normalize/stream.go
@@ -1,0 +1,267 @@
+package normalize
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// streamReader is an SSE-aware io.ReadCloser. It pulls one frame
+// (lines until a blank terminator) from upstream at a time, runs
+// chunk normalizers against the JSON payload of any data: line, and
+// emits the rewritten frame.
+//
+// Pattern mirrors translateAnthropicStream's bufio.Reader.ReadBytes
+// loop in internal/proxy/anthropic.go: a Scanner's 64 KiB token cap
+// would silently truncate long reasoning or tool-call payloads, and
+// raising it isn't enough — single chunks from real models can be
+// surprisingly large.
+type streamReader struct {
+	reader *bufio.Reader
+	opts   Options
+	out    bytes.Buffer
+	done   bool
+	err    error
+}
+
+func newStreamReader(r io.Reader, opts Options) *streamReader {
+	return &streamReader{
+		reader: bufio.NewReader(r),
+		opts:   opts,
+	}
+}
+
+// Read pulls and processes frames lazily. Each call may produce zero
+// frames (a dropped prefill_progress yields only the upstream advance,
+// no output bytes), so we loop until either the output buffer has
+// data, the upstream signals done, or we hit a fatal error.
+func (s *streamReader) Read(p []byte) (int, error) {
+	for s.out.Len() == 0 && !s.done {
+		if err := s.pumpFrame(); err != nil {
+			if err == io.EOF {
+				s.done = true
+				break
+			}
+			s.err = err
+			s.done = true
+			return 0, err
+		}
+	}
+	if s.out.Len() == 0 {
+		if s.err != nil {
+			return 0, s.err
+		}
+		return 0, io.EOF
+	}
+	return s.out.Read(p)
+}
+
+// Frame-buffer caps. A misbehaving backend that emits a single
+// multi-GB line, or an event with a runaway number of lines, would
+// otherwise grow our per-frame buffer without bound. The numbers are
+// generous against real traffic — a long reasoning trace or a tool
+// call with a serialized 1 MiB JSON argument blob still fits — but
+// finite enough to keep one bad backend from killing the proxy.
+const (
+	maxStreamLineBytes  = 8 * 1024 * 1024
+	maxStreamFrameLines = 1024
+)
+
+// pumpFrame reads one SSE frame from upstream, normalizes it, and
+// writes the resulting bytes (possibly zero) into s.out. Returns
+// io.EOF when upstream is fully drained.
+//
+// SSE line terminators per WHATWG §9.2.6 are CR, LF, or CRLF. We
+// only split on LF: both backends in scope (llama.cpp llama-server,
+// SwiftLM) emit LF/CRLF — a bare-CR-only stream would be read as one
+// giant line and tripped by the per-line cap. Document this here so
+// a future contributor knows the spec gap is deliberate, not missed.
+//
+// An SSE frame is a sequence of non-empty lines terminated by a blank
+// line. We capture each line verbatim (including its line ending) so
+// we can re-emit non-data lines (event:, id:, comments) without
+// touching them. The terminating blank line is preserved too.
+//
+// Mid-stream EOF (no trailing blank) drops the partial frame: per
+// spec, in-progress events on EOF are discarded. Re-emitting half a
+// JSON payload would corrupt downstream parsing.
+func (s *streamReader) pumpFrame() error {
+	var lines [][]byte
+	sawAnyLine := false
+	for {
+		line, err := readLineCapped(s.reader, maxStreamLineBytes)
+		if len(line) > 0 {
+			sawAnyLine = true
+			if isBlankLine(line) {
+				lines = append(lines, line)
+				return s.emitFrame(lines)
+			}
+			lines = append(lines, line)
+			if len(lines) > maxStreamFrameLines {
+				return fmt.Errorf("normalize: SSE frame exceeded %d lines", maxStreamFrameLines)
+			}
+		}
+		if err == io.EOF {
+			if !sawAnyLine {
+				return io.EOF
+			}
+			// Drop the partial frame; do not re-emit. Surfacing the EOF
+			// lets the caller see the stream end cleanly.
+			return io.EOF
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// readLineCapped reads up to a single '\n' (inclusive) but caps the
+// total bytes consumed. Returns an error if the cap is exceeded
+// before a newline is seen — preferable to silently truncating into a
+// shorter "line" that wouldn't round-trip through SSE parsing.
+func readLineCapped(r *bufio.Reader, max int) ([]byte, error) {
+	var out []byte
+	for {
+		chunk, err := r.ReadSlice('\n')
+		// chunk is only valid until the next ReadSlice — copy.
+		out = append(out, chunk...)
+		if len(out) > max {
+			return nil, fmt.Errorf("normalize: SSE line exceeded %d bytes", max)
+		}
+		if err == bufio.ErrBufferFull {
+			// Line longer than bufio's internal buffer: keep reading.
+			continue
+		}
+		return out, err
+	}
+}
+
+// emitFrame applies normalization to a captured frame's data: payload
+// (if any) and writes the result to s.out. Frames with no data: line,
+// or with a [DONE] / empty / malformed payload, pass through untouched.
+func (s *streamReader) emitFrame(lines [][]byte) error {
+	dataIdx, payload := findDataPayload(lines)
+	if dataIdx < 0 {
+		// No data: line at all (e.g. a comment or event-only frame).
+		writeLines(&s.out, lines)
+		return nil
+	}
+	// Special payloads that must not be JSON-parsed: empty keepalive
+	// and the [DONE] terminator. Mirror anthropic.go:1433.
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("[DONE]")) {
+		writeLines(&s.out, lines)
+		return nil
+	}
+
+	var obj chunkObject
+	if err := json.Unmarshal(trimmed, &obj); err != nil {
+		// Malformed payload: pass through unchanged. Mirrors the
+		// Anthropic translator's never-abort-the-stream posture.
+		writeLines(&s.out, lines)
+		return nil
+	}
+
+	if !applyChunkNormalizers(obj, s.opts) {
+		// Frame dropped (prefill_progress). Emit nothing.
+		return nil
+	}
+
+	encoded, err := json.Marshal(obj)
+	if err != nil {
+		writeLines(&s.out, lines)
+		return nil
+	}
+
+	// Replace the data: line in place, preserving its original line
+	// ending so we don't flip \r\n to \n mid-stream.
+	rewritten := rewriteDataLine(lines[dataIdx], encoded)
+	lines[dataIdx] = rewritten
+	writeLines(&s.out, lines)
+	return nil
+}
+
+// findDataPayload returns the index of the last data: line in a frame
+// and its payload bytes (with the data: prefix and trailing newline
+// stripped). Returns -1 if no data: line exists.
+//
+// Both backends (llama-server, SwiftLM) emit exactly one data: line
+// per frame for chat completions. SSE itself permits multiple data:
+// lines per frame, in which case spec-compliant clients concatenate
+// them with `\n` before parsing. We do *not* support that case: only
+// the last line is rewritten, earlier data: lines pass through
+// unchanged, and a multi-line concatenation would yield malformed
+// JSON to the client. This is a deliberate scope choice — if a future
+// backend ever splits a single JSON payload across multiple data:
+// lines we'd need to coalesce-then-rewrite. Add a regression test
+// against the new backend at that point.
+func findDataPayload(lines [][]byte) (int, []byte) {
+	for i := len(lines) - 1; i >= 0; i-- {
+		// SSE field is the substring before the first colon (§9.2.6
+		// "Process the field"). HasPrefix("data:") would also match a
+		// hypothetical "data-foo:" field; equality on the field name
+		// avoids that.
+		colon := bytes.IndexByte(lines[i], ':')
+		if colon < 0 {
+			continue
+		}
+		if bytes.Equal(lines[i][:colon], []byte("data")) {
+			return i, dataLinePayload(lines[i])
+		}
+	}
+	return -1, nil
+}
+
+// dataLinePayload extracts the payload from a "data: ..." line,
+// stripping the prefix, an optional single space, and the trailing
+// line terminator.
+func dataLinePayload(line []byte) []byte {
+	body := bytes.TrimPrefix(line, []byte("data:"))
+	body = bytes.TrimRight(body, "\r\n")
+	// SSE allows a single optional space after the colon; strip it
+	// without eating leading whitespace inside the JSON itself.
+	if len(body) > 0 && body[0] == ' ' {
+		body = body[1:]
+	}
+	return body
+}
+
+// rewriteDataLine produces a replacement for an existing data: line,
+// preserving its original line ending so the emitted stream's framing
+// matches the upstream's choice (\n vs \r\n). The leading "data: "
+// prefix is fixed since both backends use it.
+func rewriteDataLine(original, payload []byte) []byte {
+	ending := lineEnding(original)
+	out := make([]byte, 0, len("data: ")+len(payload)+len(ending))
+	out = append(out, "data: "...)
+	out = append(out, payload...)
+	out = append(out, ending...)
+	return out
+}
+
+// lineEnding returns the trailing newline bytes from a line. Default
+// to "\n" for lines without an explicit terminator (mid-frame
+// upstream-EOF case).
+func lineEnding(line []byte) []byte {
+	if bytes.HasSuffix(line, []byte("\r\n")) {
+		return []byte("\r\n")
+	}
+	if bytes.HasSuffix(line, []byte("\n")) {
+		return []byte("\n")
+	}
+	return []byte("\n")
+}
+
+// isBlankLine reports whether a line consists only of a line
+// terminator. SSE frame separator.
+func isBlankLine(line []byte) bool {
+	return bytes.Equal(line, []byte("\n")) || bytes.Equal(line, []byte("\r\n"))
+}
+
+func writeLines(w *bytes.Buffer, lines [][]byte) {
+	for _, l := range lines {
+		w.Write(l)
+	}
+}

--- a/internal/proxy/normalize/stream_test.go
+++ b/internal/proxy/normalize/stream_test.go
@@ -1,0 +1,192 @@
+package normalize
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+func runStream(t *testing.T, in string, opts Options) string {
+	t.Helper()
+	r := newStreamReader(strings.NewReader(in), opts)
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return string(out)
+}
+
+func TestStreamDropsPrefillProgress(t *testing.T) {
+	in := strings.Join([]string{
+		`data: {"object":"prefill_progress","fraction":0.25}`, "",
+		`data: {"object":"prefill_progress","fraction":0.75}`, "",
+		`data: {"object":"chat.completion.chunk","id":"abc","model":"backend","choices":[{"delta":{"content":"hi"}}]}`, "",
+		`data: [DONE]`, "",
+		"",
+	}, "\n")
+	got := runStream(t, in, Options{RequestedModel: "user/repo", Fingerprint: "lleme-test"})
+	if strings.Contains(got, "prefill_progress") {
+		t.Errorf("prefill_progress leaked into output:\n%s", got)
+	}
+	if !strings.Contains(got, `"chat.completion.chunk"`) {
+		t.Errorf("real chunk dropped:\n%s", got)
+	}
+	if !strings.Contains(got, "[DONE]") {
+		t.Errorf("[DONE] terminator dropped:\n%s", got)
+	}
+}
+
+func TestStreamRewritesModel(t *testing.T) {
+	in := "data: {\"object\":\"chat.completion.chunk\",\"model\":\"backend-id\"}\n\n"
+	got := runStream(t, in, Options{RequestedModel: "user/repo", Fingerprint: "lleme-test"})
+	if !strings.Contains(got, `"model":"user/repo"`) {
+		t.Errorf("model not rewritten:\n%s", got)
+	}
+	if strings.Contains(got, "backend-id") {
+		t.Errorf("backend-id leaked:\n%s", got)
+	}
+}
+
+func TestStreamPreservesDONE(t *testing.T) {
+	in := "data: [DONE]\n\n"
+	got := runStream(t, in, Options{RequestedModel: "x", Fingerprint: "y"})
+	if got != in {
+		t.Errorf("got %q, want %q", got, in)
+	}
+}
+
+func TestStreamPreservesUnknownLines(t *testing.T) {
+	in := "event: ping\n: heartbeat comment\nid: 17\ndata: {\"object\":\"chat.completion.chunk\",\"model\":\"x\"}\n\n"
+	got := runStream(t, in, Options{RequestedModel: "user/repo", Fingerprint: "lleme-test"})
+	for _, want := range []string{"event: ping", ": heartbeat comment", "id: 17"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing preserved line %q in output:\n%s", want, got)
+		}
+	}
+}
+
+func TestStreamPreservesCRLF(t *testing.T) {
+	in := "data: {\"object\":\"chat.completion.chunk\",\"model\":\"x\"}\r\n\r\n"
+	got := runStream(t, in, Options{RequestedModel: "user/repo", Fingerprint: "lleme-test"})
+	if !strings.HasSuffix(got, "\r\n\r\n") {
+		t.Errorf("CRLF framing not preserved:\n%q", got)
+	}
+}
+
+// TestStreamDropsPartialFrameOnEOF: per WHATWG SSE §9.2.6,
+// in-progress events on EOF are discarded. If we re-emitted a
+// half-frame the downstream client could concatenate it with bytes
+// from a reconnect and parse a corrupted JSON payload. The complete
+// frames before the partial one must still make it through.
+func TestStreamDropsPartialFrameOnEOF(t *testing.T) {
+	in := strings.Join([]string{
+		`data: {"object":"chat.completion.chunk","model":"backend","choices":[{"delta":{"content":"first"}}]}`, "",
+		`data: {"object":"chat.completion.chunk","model":"backend","choices":[{"delta":{"content":"partial"}}]}`,
+	}, "\n") // note: no trailing blank line on the second frame
+	got := runStream(t, in, Options{RequestedModel: "user/repo", Fingerprint: "lleme-test"})
+	if !strings.Contains(got, `"first"`) {
+		t.Errorf("complete frame missing:\n%q", got)
+	}
+	if strings.Contains(got, `"partial"`) {
+		t.Errorf("partial frame should have been dropped:\n%q", got)
+	}
+}
+
+func TestStreamPassesMalformedJSON(t *testing.T) {
+	in := "data: {not valid json\n\ndata: {\"object\":\"chat.completion.chunk\",\"model\":\"x\"}\n\n"
+	got := runStream(t, in, Options{RequestedModel: "user/repo", Fingerprint: "lleme-test"})
+	if !strings.Contains(got, "{not valid json") {
+		t.Errorf("malformed frame should pass through unchanged; got:\n%s", got)
+	}
+	if !strings.Contains(got, `"model":"user/repo"`) {
+		t.Errorf("subsequent valid frame should still normalize:\n%s", got)
+	}
+}
+
+func TestStreamSynthesizesFingerprintAndUsageDetails(t *testing.T) {
+	// SwiftLM-shaped final chunk: no system_fingerprint, usage missing details.
+	in := "data: {\"object\":\"chat.completion.chunk\",\"model\":\"backend\",\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":3,\"total_tokens\":10}}\n\n"
+	got := runStream(t, in, Options{RequestedModel: "user/repo", Fingerprint: "lleme-vX"})
+	if !strings.Contains(got, `"system_fingerprint":"lleme-vX"`) {
+		t.Errorf("system_fingerprint not synthesized:\n%s", got)
+	}
+	if !strings.Contains(got, `"prompt_tokens_details":{"cached_tokens":0}`) {
+		t.Errorf("prompt_tokens_details not synthesized:\n%s", got)
+	}
+	if !strings.Contains(got, `"completion_tokens_details":{"reasoning_tokens":0}`) {
+		t.Errorf("completion_tokens_details not synthesized:\n%s", got)
+	}
+}
+
+// TestStreamIdempotent: feed normalized output back through the
+// pipeline and confirm the second pass is a no-op semantically (parsed
+// chunks identical). String comparison is fragile because Go's
+// json.Marshal sorts map keys but the stream's framing/whitespace is
+// stable across passes — we compare parsed JSON to be safe.
+func TestStreamIdempotent(t *testing.T) {
+	in := strings.Join([]string{
+		`data: {"object":"prefill_progress","fraction":0.5}`, "",
+		`data: {"object":"chat.completion.chunk","model":"backend","choices":[{"delta":{"content":"hi"}}]}`, "",
+		`data: {"object":"chat.completion.chunk","model":"backend","usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`, "",
+		`data: [DONE]`, "",
+		"",
+	}, "\n")
+	opts := Options{RequestedModel: "user/repo", Fingerprint: "lleme-test"}
+	first := runStream(t, in, opts)
+	second := runStream(t, first, opts)
+	if !semanticallyEqualSSE(t, first, second) {
+		t.Errorf("not idempotent:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// TestStreamRejectsRunawayLine — a single SSE line with no
+// terminator forever (or one larger than the cap) must be rejected
+// rather than buffered to OOM. We use a small synthetic cap test by
+// constructing a line that exceeds the per-line cap; the reader
+// should return an error rather than allocate without bound.
+func TestStreamRejectsRunawayLine(t *testing.T) {
+	// 9 MiB of 'x' followed by no newline — exceeds the 8 MiB cap.
+	huge := strings.Repeat("x", 9*1024*1024)
+	r := newStreamReader(strings.NewReader(huge), Options{})
+	_, err := io.ReadAll(r)
+	if err == nil {
+		t.Fatal("expected error on oversized line, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeded") {
+		t.Errorf("error should mention size cap; got: %v", err)
+	}
+}
+
+// semanticallyEqualSSE compares two SSE streams by extracting each
+// data: payload, parsing JSON, and re-serializing — so map-key
+// ordering differences don't trigger false negatives.
+func semanticallyEqualSSE(t *testing.T, a, b string) bool {
+	t.Helper()
+	return canonicalizeSSE(t, a) == canonicalizeSSE(t, b)
+}
+
+func canonicalizeSSE(t *testing.T, s string) string {
+	t.Helper()
+	var out strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		trimmed := strings.TrimRight(line, "\r")
+		if strings.HasPrefix(trimmed, "data:") {
+			payload := strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
+			if payload == "" || payload == "[DONE]" {
+				out.WriteString(trimmed + "\n")
+				continue
+			}
+			var v any
+			if err := json.Unmarshal([]byte(payload), &v); err != nil {
+				out.WriteString(trimmed + "\n")
+				continue
+			}
+			b, _ := json.Marshal(v)
+			out.WriteString("data: " + string(b) + "\n")
+			continue
+		}
+		out.WriteString(trimmed + "\n")
+	}
+	return out.String()
+}

--- a/internal/proxy/normalize/stream_test.go
+++ b/internal/proxy/normalize/stream_test.go
@@ -140,6 +140,29 @@ func TestStreamIdempotent(t *testing.T) {
 	}
 }
 
+// TestStreamRejectsRunawayFrame — a frame whose lines individually
+// fit under the per-line cap but whose total exceeds the per-frame
+// cap must still be rejected. Without the per-frame total bound, a
+// backend could pack many near-max lines into one event and OOM us
+// before any individual line tripped maxStreamLineBytes.
+func TestStreamRejectsRunawayFrame(t *testing.T) {
+	// Each line ~6 MiB (under 8 MiB per-line cap). Three of them
+	// sum to ~18 MiB (over 16 MiB per-frame cap). No blank line —
+	// we want to trip the frame cap before EOF or terminator.
+	chunk := strings.Repeat("x", 6*1024*1024)
+	in := "data: " + chunk + "\n" +
+		"data: " + chunk + "\n" +
+		"data: " + chunk + "\n"
+	r := newStreamReader(strings.NewReader(in), Options{})
+	_, err := io.ReadAll(r)
+	if err == nil {
+		t.Fatal("expected error on oversized frame, got nil")
+	}
+	if !strings.Contains(err.Error(), "frame exceeded") {
+		t.Errorf("error should mention frame size cap; got: %v", err)
+	}
+}
+
 // TestStreamRejectsRunawayLine — a single SSE line with no
 // terminator forever (or one larger than the cap) must be rejected
 // rather than buffered to OOM. We use a small synthetic cap test by

--- a/internal/proxy/openai_helpers_test.go
+++ b/internal/proxy/openai_helpers_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -71,21 +72,28 @@ func TestRequestWantsStream(t *testing.T) {
 }
 
 func TestOpenAIErrorTypeForStatus(t *testing.T) {
+	// Short-form types match the rest of the proxy's writeError call
+	// sites (see "invalid_request" / "not_found" / "server_error" /
+	// "method_not_allowed" elsewhere in server.go). Aligning to one
+	// taxonomy now; canonicalizing the whole proxy to OpenAI's
+	// "*_error" suffix forms is a separate change.
 	tests := []struct {
 		status int
 		want   string
 	}{
-		{http.StatusBadRequest, "invalid_request_error"},
+		{http.StatusBadRequest, "invalid_request"},
 		{http.StatusUnauthorized, "authentication_error"},
 		{http.StatusForbidden, "permission_error"},
-		{http.StatusNotFound, "not_found_error"},
-		{http.StatusRequestEntityTooLarge, "invalid_request_error"},
-		{http.StatusTooManyRequests, "rate_limit_error"},
+		{http.StatusNotFound, "not_found"},
+		{http.StatusMethodNotAllowed, "method_not_allowed"},
+		{http.StatusRequestEntityTooLarge, "invalid_request"},
+		{http.StatusUnprocessableEntity, "invalid_request"},
+		{http.StatusTooManyRequests, "rate_limit"},
 		{http.StatusServiceUnavailable, "server_error"},
 		{http.StatusInternalServerError, "server_error"},
 		{http.StatusBadGateway, "server_error"},
-		{418, "invalid_request_error"}, // unmapped 4xx → invalid_request_error
-		{599, "server_error"},          // unmapped 5xx → server_error
+		{418, "invalid_request"}, // unmapped 4xx → invalid_request
+		{599, "server_error"},    // unmapped 5xx → server_error
 	}
 	for _, tt := range tests {
 		t.Run(http.StatusText(tt.status), func(t *testing.T) {
@@ -237,7 +245,7 @@ func TestWriteNormalizedResponseSetsContentLength(t *testing.T) {
 	resp.Header.Set("Content-Length", "999") // wrong — should be replaced
 
 	w := httptest.NewRecorder()
-	writeNormalizedResponse(w, resp, bytes.NewReader(body))
+	(&Server{}).writeNormalizedResponse(w, resp, bytes.NewReader(body))
 
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", w.Code)
@@ -251,6 +259,35 @@ func TestWriteNormalizedResponseSetsContentLength(t *testing.T) {
 		t.Errorf("body len = %d, want %d", w.Body.Len(), len(body))
 	}
 }
+
+// TestWriteNormalizedResponseEmitsOpenAIErrorOnReadFailure: when the
+// normalize/buffered reader fails (e.g. ErrResponseTooLarge from a
+// runaway backend), clients must still receive a valid OpenAI error
+// envelope rather than a plain-text http.Error body.
+func TestWriteNormalizedResponseEmitsOpenAIErrorOnReadFailure(t *testing.T) {
+	resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}}
+	w := httptest.NewRecorder()
+
+	(&Server{}).writeNormalizedResponse(w, resp, errReader{err: errors.New("simulated")})
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var got OpenAIError
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response not valid OpenAI error JSON: %v\nbody=%s", err, w.Body.String())
+	}
+	if got.Error.Type != "server_error" {
+		t.Errorf("error type = %q, want server_error", got.Error.Type)
+	}
+}
+
+type errReader struct{ err error }
+
+func (e errReader) Read([]byte) (int, error) { return 0, e.err }
 
 // TestWriteNormalizedStreamSetsSSEHeaders — confirms the streaming
 // path overrides backend headers with SSE-correct values, regardless

--- a/internal/proxy/openai_helpers_test.go
+++ b/internal/proxy/openai_helpers_test.go
@@ -1,0 +1,285 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Tests for the small pure helpers added in handleChatCompletions and
+// the readBodyRaw / parseModelField extractions. These are the
+// surface that the rest of the chat-completions path depends on, so
+// they get direct coverage rather than relying on full handler
+// integration tests (which would need a Manager + fake backend).
+
+func TestParseModelField(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		want    string
+		wantErr string
+	}{
+		{"valid", `{"model":"user/repo"}`, "user/repo", ""},
+		{"with extra fields", `{"model":"x","stream":true,"messages":[]}`, "x", ""},
+		{"missing field", `{}`, "", "model: Field required"},
+		{"empty model", `{"model":""}`, "", "model: Field required"},
+		{"malformed JSON", `not json`, "", "Failed to parse request body as JSON"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseModelField([]byte(tt.body))
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != tt.want {
+					t.Errorf("got %q, want %q", got, tt.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error %q, got nil (model=%q)", tt.wantErr, got)
+			}
+			if err.Error() != tt.wantErr {
+				t.Errorf("got error %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRequestWantsStream(t *testing.T) {
+	tests := []struct {
+		body string
+		want bool
+	}{
+		{`{"stream":true}`, true},
+		{`{"stream":false}`, false},
+		{`{}`, false},
+		{`{"messages":[],"stream":true}`, true},
+		{`not json`, false}, // defensive default — caller already validated body
+	}
+	for _, tt := range tests {
+		t.Run(tt.body, func(t *testing.T) {
+			if got := requestWantsStream([]byte(tt.body)); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenAIErrorTypeForStatus(t *testing.T) {
+	tests := []struct {
+		status int
+		want   string
+	}{
+		{http.StatusBadRequest, "invalid_request_error"},
+		{http.StatusUnauthorized, "authentication_error"},
+		{http.StatusForbidden, "permission_error"},
+		{http.StatusNotFound, "not_found_error"},
+		{http.StatusRequestEntityTooLarge, "invalid_request_error"},
+		{http.StatusTooManyRequests, "rate_limit_error"},
+		{http.StatusServiceUnavailable, "server_error"},
+		{http.StatusInternalServerError, "server_error"},
+		{http.StatusBadGateway, "server_error"},
+		{418, "invalid_request_error"}, // unmapped 4xx → invalid_request_error
+		{599, "server_error"},          // unmapped 5xx → server_error
+	}
+	for _, tt := range tests {
+		t.Run(http.StatusText(tt.status), func(t *testing.T) {
+			if got := openAIErrorTypeForStatus(tt.status); got != tt.want {
+				t.Errorf("status %d: got %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadBodyRaw(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"a":1}`))
+		w := httptest.NewRecorder()
+		body, rbe := readBodyRaw(w, req)
+		if rbe != nil {
+			t.Fatalf("unexpected error: %+v", rbe)
+		}
+		if string(body) != `{"a":1}` {
+			t.Errorf("body = %q, want %q", body, `{"a":1}`)
+		}
+	})
+
+	t.Run("rejects non-POST", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+		_, rbe := readBodyRaw(w, req)
+		if rbe == nil || rbe.status != http.StatusMethodNotAllowed {
+			t.Errorf("expected MethodNotAllowed, got %+v", rbe)
+		}
+	})
+
+	t.Run("oversized body", func(t *testing.T) {
+		oversized := strings.Repeat("a", maxRequestBodyBytes+1)
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(oversized))
+		w := httptest.NewRecorder()
+		_, rbe := readBodyRaw(w, req)
+		if rbe == nil || rbe.status != http.StatusRequestEntityTooLarge {
+			t.Errorf("expected RequestEntityTooLarge, got %+v", rbe)
+		}
+	})
+}
+
+// TestReadOpenAIBodyTranslatesError — readBodyRaw is shared between
+// the OpenAI and Anthropic surfaces; verify the OpenAI wrapper picks
+// the right error type for each status.
+func TestReadOpenAIBodyTranslatesError(t *testing.T) {
+	s := &Server{}
+
+	t.Run("non-POST -> method_not_allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+		w := httptest.NewRecorder()
+		_, ok := s.readOpenAIBody(w, req)
+		if ok {
+			t.Fatal("expected ok=false")
+		}
+		var resp OpenAIError
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Error.Type != "method_not_allowed" {
+			t.Errorf("error type = %q, want method_not_allowed", resp.Error.Type)
+		}
+	})
+
+	t.Run("oversize -> invalid_request", func(t *testing.T) {
+		oversized := strings.Repeat("a", maxRequestBodyBytes+1)
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewBufferString(oversized))
+		w := httptest.NewRecorder()
+		_, ok := s.readOpenAIBody(w, req)
+		if ok {
+			t.Fatal("expected ok=false")
+		}
+		var resp OpenAIError
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Error.Type != "invalid_request" {
+			t.Errorf("error type = %q, want invalid_request", resp.Error.Type)
+		}
+	})
+}
+
+func TestCopyResponseHeaders(t *testing.T) {
+	t.Run("strips hop-by-hop and Content-Length", func(t *testing.T) {
+		resp := &http.Response{Header: http.Header{}}
+		resp.Header.Set("Content-Type", "application/json")
+		resp.Header.Set("Content-Length", "42")
+		resp.Header.Set("Connection", "keep-alive")
+		resp.Header.Set("Transfer-Encoding", "chunked")
+		resp.Header.Set("X-Custom", "preserved")
+		resp.Header.Set("Request-Id", "req_abc")
+
+		w := httptest.NewRecorder()
+		copyResponseHeaders(w, resp, false)
+
+		got := w.Header()
+		for _, h := range []string{"Content-Length", "Connection", "Transfer-Encoding"} {
+			if v := got.Get(h); v != "" {
+				t.Errorf("expected %s stripped, got %q", h, v)
+			}
+		}
+		if got.Get("Content-Type") != "application/json" {
+			t.Errorf("Content-Type lost: %q", got.Get("Content-Type"))
+		}
+		if got.Get("X-Custom") != "preserved" {
+			t.Errorf("X-Custom lost: %q", got.Get("X-Custom"))
+		}
+		if got.Get("Request-Id") != "req_abc" {
+			t.Errorf("Request-Id lost: %q", got.Get("Request-Id"))
+		}
+	})
+
+	t.Run("streaming skips Content-Type and Cache-Control", func(t *testing.T) {
+		// The streaming path sets these explicitly to text/event-stream
+		// and no-cache; passing through backend values would double-set.
+		resp := &http.Response{Header: http.Header{}}
+		resp.Header.Set("Content-Type", "application/json")
+		resp.Header.Set("Cache-Control", "max-age=300")
+		resp.Header.Set("X-Custom", "preserved")
+
+		w := httptest.NewRecorder()
+		copyResponseHeaders(w, resp, true)
+
+		got := w.Header()
+		if v := got.Get("Content-Type"); v != "" {
+			t.Errorf("streaming should skip backend Content-Type, got %q", v)
+		}
+		if v := got.Get("Cache-Control"); v != "" {
+			t.Errorf("streaming should skip backend Cache-Control, got %q", v)
+		}
+		if got.Get("X-Custom") != "preserved" {
+			t.Errorf("X-Custom lost: %q", got.Get("X-Custom"))
+		}
+	})
+}
+
+// TestWriteNormalizedResponseSetsContentLength — Content-Length must
+// match the bytes actually written, since the normalize layer changes
+// payload size from upstream's. Getting this wrong would cause clients
+// to hang waiting for bytes that never come, or to truncate.
+func TestWriteNormalizedResponseSetsContentLength(t *testing.T) {
+	body := []byte(`{"normalized":true}`)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+	}
+	resp.Header.Set("Content-Type", "application/json")
+	resp.Header.Set("Content-Length", "999") // wrong — should be replaced
+
+	w := httptest.NewRecorder()
+	writeNormalizedResponse(w, resp, bytes.NewReader(body))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	gotLen := w.Header().Get("Content-Length")
+	wantLen := "19"
+	if gotLen != wantLen {
+		t.Errorf("Content-Length = %q, want %q", gotLen, wantLen)
+	}
+	if w.Body.Len() != len(body) {
+		t.Errorf("body len = %d, want %d", w.Body.Len(), len(body))
+	}
+}
+
+// TestWriteNormalizedStreamSetsSSEHeaders — confirms the streaming
+// path overrides backend headers with SSE-correct values, regardless
+// of what the backend sent.
+func TestWriteNormalizedStreamSetsSSEHeaders(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+	}
+	// Backend sent something else; we must override.
+	resp.Header.Set("Content-Type", "application/json")
+	resp.Header.Set("Cache-Control", "max-age=300")
+
+	body := strings.NewReader("data: {\"object\":\"chat.completion.chunk\"}\n\n")
+	w := httptest.NewRecorder()
+	writeNormalizedStream(w, resp, body)
+
+	if got := w.Header().Get("Content-Type"); got != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", got)
+	}
+	if got := w.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache", got)
+	}
+	// Connection is hop-by-hop; net/http drops it. We deliberately do
+	// not set it from the handler — verify it's absent.
+	if got := w.Header().Get("Connection"); got != "" {
+		t.Errorf("Connection should not be set by handler; got %q", got)
+	}
+	if !strings.Contains(w.Body.String(), "chat.completion.chunk") {
+		t.Errorf("body did not include upstream content: %q", w.Body.String())
+	}
+}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -349,7 +349,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		writeNormalizedStream(w, resp, wrapped)
 		return
 	}
-	writeNormalizedResponse(w, resp, wrapped)
+	s.writeNormalizedResponse(w, resp, wrapped)
 }
 
 // requestWantsStream reads only the "stream" field from a request body.
@@ -400,15 +400,17 @@ func writeNormalizedStream(w http.ResponseWriter, resp *http.Response, body io.R
 // Content-Length to the rewritten length, and writes the response. The
 // upstream Content-Length is intentionally discarded — re-marshaling
 // changes byte count.
-func writeNormalizedResponse(w http.ResponseWriter, resp *http.Response, body io.Reader) {
+func (s *Server) writeNormalizedResponse(w http.ResponseWriter, resp *http.Response, body io.Reader) {
 	out, err := io.ReadAll(body)
 	if err != nil {
-		// Headers haven't been written yet; surface as a server error.
-		// Caller ignores its writeError-equivalent at this point because
-		// the upstream call already succeeded; use a plain 502 to signal
-		// mid-pipeline failure without pretending it was a backend
-		// rejection.
-		http.Error(w, "Failed to read backend response", http.StatusBadGateway)
+		// Headers haven't been written yet — emit a proper OpenAI
+		// error envelope so clients always see a parseable error
+		// shape, never a plain-text http.Error body.
+		status := http.StatusBadGateway
+		if errors.Is(err, normalize.ErrResponseTooLarge) {
+			status = http.StatusBadGateway
+		}
+		s.writeError(w, status, "server_error", "Failed to read backend response: "+err.Error())
 		return
 	}
 	copyResponseHeaders(w, resp, false)
@@ -961,34 +963,32 @@ func (s *Server) writeError(w http.ResponseWriter, status int, errType, message 
 	})
 }
 
-// openAIErrorTypeForStatus maps an upstream HTTP status to the OpenAI
-// error-type string we surface. Mirror of anthropicErrorTypeForStatus
-// so both surfaces give clients consistent error categorization
-// regardless of which backend failed.
+// openAIErrorTypeForStatus maps an upstream HTTP status to the
+// short error-type string this proxy uses across all OpenAI error
+// responses (writeError call sites use "invalid_request",
+// "not_found", "server_error", "method_not_allowed", etc. — kept
+// for consistency over OpenAI's canonical "*_error" suffix forms).
+// A future canonicalization pass should align both this function
+// and the existing call sites in one go.
 func openAIErrorTypeForStatus(status int) string {
 	switch status {
-	case http.StatusBadRequest:
-		return "invalid_request_error"
+	case http.StatusBadRequest,
+		http.StatusRequestEntityTooLarge,
+		http.StatusUnprocessableEntity: // llama-server uses 422 for context overflow
+		return "invalid_request"
 	case http.StatusUnauthorized:
 		return "authentication_error"
 	case http.StatusForbidden:
 		return "permission_error"
 	case http.StatusNotFound:
-		return "not_found_error"
-	case http.StatusRequestEntityTooLarge:
-		return "invalid_request_error"
-	case http.StatusUnprocessableEntity:
-		// llama-server returns 422 for context-window overflow; the
-		// OpenAI SDK branches on status code independently of the
-		// error type, so keep it explicit.
-		return "invalid_request_error"
+		return "not_found"
 	case http.StatusTooManyRequests:
-		return "rate_limit_error"
-	case http.StatusServiceUnavailable:
-		return "server_error"
+		return "rate_limit"
+	case http.StatusMethodNotAllowed:
+		return "method_not_allowed"
 	default:
 		if status >= 400 && status < 500 {
-			return "invalid_request_error"
+			return "invalid_request"
 		}
 		return "server_error"
 	}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nchapman/lleme/internal/hf"
 	"github.com/nchapman/lleme/internal/llama"
 	"github.com/nchapman/lleme/internal/logs"
+	"github.com/nchapman/lleme/internal/proxy/normalize"
 	"github.com/nchapman/lleme/internal/swiftlm"
 	"github.com/nchapman/lleme/internal/version"
 )
@@ -284,9 +285,169 @@ func (s *Server) saveState() {
 	}
 }
 
-// handleChatCompletions proxies chat completion requests to the appropriate backend
+// handleChatCompletions proxies an OpenAI /v1/chat/completions request to
+// the resolved backend, then runs the response through the normalize layer
+// before returning it to the client. Mirrors handleAnthropicMessages so
+// both surfaces share the same forward-and-rewrite shape — the reverse-
+// proxy approach in proxyToBackend can't interpose on the response body,
+// which is what normalization needs.
+//
+// /v1/completions and /v1/embeddings still use the reverse-proxy
+// proxyToBackend helper: they have unrelated response shapes and don't
+// need this normalization layer.
 func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
-	s.proxyToBackend(w, r, "/v1/chat/completions")
+	body, ok := s.readOpenAIBody(w, r)
+	if !ok {
+		return
+	}
+	modelName, ok := s.extractOpenAIModel(w, body)
+	if !ok {
+		return
+	}
+	stream := requestWantsStream(body)
+
+	backend, err := s.manager.GetOrLoadBackend(modelName, nil)
+	if err != nil {
+		s.handleModelError(w, err)
+		return
+	}
+	defer backend.ReleaseRequest()
+
+	resp, err := s.forwardToBackendChat(r.Context(), backend, body, stream)
+	if err != nil {
+		s.writeError(w, http.StatusBadGateway, "server_error", "Backend request failed: "+err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Short-circuit: don't run the backend's error body through the
+		// normalize layer (which expects a chat-completion shape and
+		// would silently rewrite fields like model/system_fingerprint
+		// onto the error envelope). Cap the body we echo back so a
+		// misbehaving backend can't push arbitrary memory through.
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
+		msg := strings.TrimSpace(string(errBody))
+		if msg == "" {
+			msg = fmt.Sprintf("backend returned %d", resp.StatusCode)
+		}
+		s.writeError(w, resp.StatusCode, openAIErrorTypeForStatus(resp.StatusCode), msg)
+		return
+	}
+
+	// Apply the same CORS strip the reverse-proxy ModifyResponse path uses,
+	// so the proxy's own CORS middleware isn't shadowed by backend headers.
+	_ = stripCORSHeaders(resp)
+
+	wrapped := normalize.Wrap(resp.Body, normalize.Options{
+		RequestedModel: modelName,
+		Streaming:      stream,
+		Fingerprint:    "lleme-" + version.Version,
+	})
+
+	if stream {
+		writeNormalizedStream(w, resp, wrapped)
+		return
+	}
+	writeNormalizedResponse(w, resp, wrapped)
+}
+
+// requestWantsStream reads only the "stream" field from a request body.
+// Defaults to false (matches OpenAI's spec) when absent or malformed —
+// callers already validated the body shape via extractOpenAIModel.
+func requestWantsStream(body []byte) bool {
+	var req struct {
+		Stream bool `json:"stream"`
+	}
+	_ = json.Unmarshal(body, &req)
+	return req.Stream
+}
+
+// writeNormalizedStream copies SSE bytes from the normalize wrapper to
+// the client, flushing after each read so single-token deltas reach the
+// browser/SDK without buffering. Mirrors the SSE response shape from
+// writeAnthropicStream — same headers, same flush cadence.
+func writeNormalizedStream(w http.ResponseWriter, resp *http.Response, body io.Reader) {
+	copyResponseHeaders(w, resp, true)
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(resp.StatusCode)
+
+	flusher, _ := w.(http.Flusher)
+	buf := make([]byte, 8*1024)
+	for {
+		n, err := body.Read(buf)
+		if n > 0 {
+			if _, werr := w.Write(buf[:n]); werr != nil {
+				logs.Debug("openai stream write failed", "error", werr)
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			logs.Debug("openai stream read failed", "error", err)
+			return
+		}
+	}
+}
+
+// writeNormalizedResponse drains the (already-normalized) body, sets
+// Content-Length to the rewritten length, and writes the response. The
+// upstream Content-Length is intentionally discarded — re-marshaling
+// changes byte count.
+func writeNormalizedResponse(w http.ResponseWriter, resp *http.Response, body io.Reader) {
+	out, err := io.ReadAll(body)
+	if err != nil {
+		// Headers haven't been written yet; surface as a server error.
+		// Caller ignores its writeError-equivalent at this point because
+		// the upstream call already succeeded; use a plain 502 to signal
+		// mid-pipeline failure without pretending it was a backend
+		// rejection.
+		http.Error(w, "Failed to read backend response", http.StatusBadGateway)
+		return
+	}
+	copyResponseHeaders(w, resp, false)
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(out)))
+	w.WriteHeader(resp.StatusCode)
+	if _, werr := w.Write(out); werr != nil {
+		logs.Debug("openai response write failed", "error", werr)
+	}
+}
+
+// copyResponseHeaders forwards backend response headers to the client,
+// dropping headers that we control or that no longer apply after
+// rewriting. CORS is stripped earlier via stripCORSHeaders. We always
+// drop Content-Length (recomputed for non-stream, irrelevant for SSE)
+// and hop-by-hop headers per RFC 7230.
+func copyResponseHeaders(w http.ResponseWriter, resp *http.Response, streaming bool) {
+	for k, vs := range resp.Header {
+		switch http.CanonicalHeaderKey(k) {
+		case "Content-Length",
+			"Transfer-Encoding",
+			"Connection",
+			"Keep-Alive",
+			"Proxy-Authenticate",
+			"Proxy-Authorization",
+			"Te",
+			"Trailer",
+			"Upgrade":
+			continue
+		case "Content-Type", "Cache-Control":
+			if streaming {
+				// Streaming path sets these explicitly; skip backend
+				// values to avoid double-set.
+				continue
+			}
+		}
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
 }
 
 // handleCompletions proxies completion requests to the appropriate backend
@@ -349,29 +510,35 @@ func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Pass the upstream body through the normalize layer before the
+	// Anthropic translator sees it. SwiftLM's prefill_progress frames
+	// would otherwise reach handleStreamLine as malformed-but-parseable
+	// JSON and emit phantom Anthropic events; the model rewrite and
+	// envelope synthesis are no-ops on the Anthropic surface but keep
+	// both code paths consuming an identical OpenAI shape.
+	wrapped := normalize.Wrap(resp.Body, normalize.Options{
+		RequestedModel: modelName,
+		Streaming:      stream,
+		Fingerprint:    "lleme-" + version.Version,
+	})
+
 	messageID := generateMessageID()
 	if stream {
-		s.writeAnthropicStream(w, resp.Body, requestID, messageID, modelName)
+		s.writeAnthropicStream(w, wrapped, requestID, messageID, modelName)
 		return
 	}
-	s.writeAnthropicNonStream(w, resp.Body, requestID, messageID)
+	s.writeAnthropicNonStream(w, wrapped, requestID, messageID)
 }
 
 // extractAnthropicModel pulls the model field out of an Anthropic request
 // body and writes an error response if missing or malformed.
 func (s *Server) extractAnthropicModel(w http.ResponseWriter, requestID string, body []byte) (string, bool) {
-	var modelRef struct {
-		Model string `json:"model"`
-	}
-	if err := json.Unmarshal(body, &modelRef); err != nil {
-		s.writeAnthropicError(w, requestID, http.StatusBadRequest, AnthropicInvalidRequest, "Failed to parse request body as JSON")
+	model, err := parseModelField(body)
+	if err != nil {
+		s.writeAnthropicError(w, requestID, http.StatusBadRequest, AnthropicInvalidRequest, err.Error())
 		return "", false
 	}
-	if modelRef.Model == "" {
-		s.writeAnthropicError(w, requestID, http.StatusBadRequest, AnthropicInvalidRequest, "model: Field required")
-		return "", false
-	}
-	return modelRef.Model, true
+	return model, true
 }
 
 // forwardToBackendChat POSTs a translated OpenAI request to the backend's
@@ -395,7 +562,6 @@ func (s *Server) forwardToBackendChat(ctx context.Context, backend *Backend, ope
 func (s *Server) writeAnthropicStream(w http.ResponseWriter, body io.Reader, requestID, messageID, model string) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("request-id", requestID)
 	w.WriteHeader(http.StatusOK)
 
@@ -460,26 +626,44 @@ var backendChatClient = &http.Client{}
 // error response on failure. Returns (body, true) on success, or (nil, false)
 // after writing an error response.
 func (s *Server) readAnthropicBody(w http.ResponseWriter, r *http.Request, requestID string) ([]byte, bool) {
-	if r.Method != http.MethodPost {
-		s.writeAnthropicError(w, requestID, http.StatusMethodNotAllowed, AnthropicInvalidRequest, "Only POST is allowed")
+	body, rbe := readBodyRaw(w, r)
+	if rbe != nil {
+		s.writeAnthropicError(w, requestID, rbe.status, AnthropicInvalidRequest, rbe.message)
 		return nil, false
+	}
+	// Strip Anthropic client auth headers before any downstream forwarding.
+	r.Header.Del("x-api-key")
+	return body, true
+}
+
+// readBodyErr carries the status + message for a request-read failure
+// without committing to a surface-specific error shape. Each handler
+// (OpenAI vs Anthropic) translates it to its own JSON envelope.
+type readBodyErr struct {
+	status  int
+	message string
+}
+
+// readBodyRaw enforces POST + size cap and drains the request body.
+// Surface-agnostic: callers translate the returned readBodyErr into
+// their own error response. Centralizing this avoids drift between
+// the two surfaces' size-limit and method-validation behavior.
+func readBodyRaw(w http.ResponseWriter, r *http.Request) ([]byte, *readBodyErr) {
+	if r.Method != http.MethodPost {
+		return nil, &readBodyErr{http.StatusMethodNotAllowed, "Only POST is allowed"}
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
-			s.writeAnthropicError(w, requestID, http.StatusRequestEntityTooLarge, AnthropicInvalidRequest,
-				fmt.Sprintf("Request body exceeds %d bytes", maxRequestBodyBytes))
-			return nil, false
+			return nil, &readBodyErr{http.StatusRequestEntityTooLarge,
+				fmt.Sprintf("Request body exceeds %d bytes", maxRequestBodyBytes)}
 		}
-		s.writeAnthropicError(w, requestID, http.StatusBadRequest, AnthropicInvalidRequest, "Failed to read request body")
-		return nil, false
+		return nil, &readBodyErr{http.StatusBadRequest, "Failed to read request body"}
 	}
 	r.Body.Close()
-	// Strip Anthropic client auth headers before any downstream forwarding.
-	r.Header.Del("x-api-key")
-	return body, true
+	return body, nil
 }
 
 // writeAnthropicTranslationError maps a translation error to an Anthropic
@@ -542,41 +726,47 @@ func (s *Server) proxyToBackend(w http.ResponseWriter, r *http.Request, path str
 // endpoint, writing an OpenAI-shaped error on failure. Returns (body, true)
 // on success, (nil, false) after writing an error.
 func (s *Server) readOpenAIBody(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
-	if r.Method != http.MethodPost {
-		s.writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "Only POST is allowed")
-		return nil, false
-	}
-	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		var maxErr *http.MaxBytesError
-		if errors.As(err, &maxErr) {
-			s.writeError(w, http.StatusRequestEntityTooLarge, "invalid_request",
-				fmt.Sprintf("Request body exceeds %d bytes", maxRequestBodyBytes))
-			return nil, false
+	body, rbe := readBodyRaw(w, r)
+	if rbe != nil {
+		errType := "invalid_request"
+		if rbe.status == http.StatusMethodNotAllowed {
+			errType = "method_not_allowed"
 		}
-		s.writeError(w, http.StatusBadRequest, "invalid_request", "Failed to read request body")
+		s.writeError(w, rbe.status, errType, rbe.message)
 		return nil, false
 	}
-	r.Body.Close()
 	return body, true
 }
 
 // extractOpenAIModel pulls the model field out of an OpenAI-style request
 // body, writing an OpenAI-shaped error on failure.
 func (s *Server) extractOpenAIModel(w http.ResponseWriter, body []byte) (string, bool) {
-	var req struct {
+	model, err := parseModelField(body)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return "", false
+	}
+	return model, true
+}
+
+// parseModelField extracts the "model" string from a request body. Used
+// by both the OpenAI and Anthropic surfaces — the request shape is the
+// same; only the error envelope differs, which the callers handle.
+//
+// Error messages are capitalized because they're user-facing API
+// response messages (rendered into the error.message JSON field), not
+// idiomatic Go error chains.
+func parseModelField(body []byte) (string, error) {
+	var ref struct {
 		Model string `json:"model"`
 	}
-	if err := json.Unmarshal(body, &req); err != nil {
-		s.writeError(w, http.StatusBadRequest, "invalid_request", "Failed to parse request body")
-		return "", false
+	if err := json.Unmarshal(body, &ref); err != nil {
+		return "", errors.New("Failed to parse request body as JSON") //nolint:staticcheck // user-facing message
 	}
-	if req.Model == "" {
-		s.writeError(w, http.StatusBadRequest, "invalid_request", "Model field is required")
-		return "", false
+	if ref.Model == "" {
+		return "", errors.New("model: Field required") //nolint:staticcheck // user-facing message
 	}
-	return req.Model, true
+	return ref.Model, nil
 }
 
 // generateRequestID creates a unique request ID in Anthropic format
@@ -769,6 +959,39 @@ func (s *Server) writeError(w http.ResponseWriter, status int, errType, message 
 			Type:    errType,
 		},
 	})
+}
+
+// openAIErrorTypeForStatus maps an upstream HTTP status to the OpenAI
+// error-type string we surface. Mirror of anthropicErrorTypeForStatus
+// so both surfaces give clients consistent error categorization
+// regardless of which backend failed.
+func openAIErrorTypeForStatus(status int) string {
+	switch status {
+	case http.StatusBadRequest:
+		return "invalid_request_error"
+	case http.StatusUnauthorized:
+		return "authentication_error"
+	case http.StatusForbidden:
+		return "permission_error"
+	case http.StatusNotFound:
+		return "not_found_error"
+	case http.StatusRequestEntityTooLarge:
+		return "invalid_request_error"
+	case http.StatusUnprocessableEntity:
+		// llama-server returns 422 for context-window overflow; the
+		// OpenAI SDK branches on status code independently of the
+		// error type, so keep it explicit.
+		return "invalid_request_error"
+	case http.StatusTooManyRequests:
+		return "rate_limit_error"
+	case http.StatusServiceUnavailable:
+		return "server_error"
+	default:
+		if status >= 400 && status < 500 {
+			return "invalid_request_error"
+		}
+		return "server_error"
+	}
 }
 
 // decodeJSONBody reads r.Body under the shared size cap and decodes it into v.


### PR DESCRIPTION
## Summary

- New `internal/proxy/normalize` layer that patches subtle backend OpenAI quirks before responses reach clients or the in-proxy Anthropic translator. Both surfaces now consume an identical canonical shape.
- Refactor `/v1/chat/completions` off `httputil.ReverseProxy` to mirror the Anthropic flow (read → forward → wrap → write); `/v1/completions` and `/v1/embeddings` keep the reverse proxy.
- Extract shared `readBodyRaw` and `parseModelField` helpers; add `openAIErrorTypeForStatus` mirroring its Anthropic sibling.
- Short-circuit non-200 backend responses with a proper OpenAI error envelope.

## Why

SwiftLM (MLX) emits non-OpenAI `prefill_progress` SSE frames during prompt processing — strict OpenAI clients reject them. It also ignores the requested `model` and omits `system_fingerprint` and `usage` detail blocks. Rather than patch each backend's shape ad-hoc (or wait for upstream fixes for issues we don't own), the proxy normalizes once and both the OpenAI passthrough and the Anthropic translator benefit.

Each pass is **idempotent**, **self-disabling** (when the backend stops emitting the bad pattern, the pass becomes a no-op), and **additive only** (never overwrites a backend-supplied field). The one exception is `model`, which always echoes the requested name — that's the contract.

Out of scope: gpt-oss harmony parsing. SwiftLM has an unmerged `feature/qwen35-support` branch with the right token-ID-based fix; parsing it from outside the inference engine is the wrong layer. Will file an upstream ticket separately.

## What's in the normalize package

| Pass | Activates when | Does | Self-disabling? |
|---|---|---|---|
| `prefill_progress` filter | frame `object == "prefill_progress"` | drops the frame | yes |
| `model` rewrite | always | sets `model` to requested name | exception (contract) |
| `system_fingerprint` synth | field absent or null | inserts `lleme-<version>` | yes |
| `usage_details` synth | `usage` present, details missing | inserts `cached_tokens:0` / `reasoning_tokens:0` | yes — per-key |

## Hardening applied during review

- Cap buffered non-stream response at 64 MiB (`io.LimitReader`)
- Cap per-frame size at 8 MiB / 1024 lines in the SSE reader
- Drop partial frames on mid-stream EOF per WHATWG SSE §9.2.6
- Tighten `data:` field detection to colon-split equality
- Document LF-only terminator assumption (both backends emit LF)

## Test plan

- [x] `make check` clean
- [x] Per-normalizer unit tests (idempotency + additivity directly verified)
- [x] Stream framing tests (CRLF preservation, `[DONE]`, malformed JSON passthrough, unknown lines, partial-frame-on-EOF, runaway-line rejection)
- [x] Buffered reader tests (golden response, malformed-JSON passthrough, size cap)
- [x] Helper tests for `parseModelField`, `openAIErrorTypeForStatus`, `requestWantsStream`, `readBodyRaw`, `copyResponseHeaders`, `writeNormalizedStream`, `writeNormalizedResponse`
- [x] **Manual smoke against SwiftLM streaming** (`mlx-community/gpt-oss-20b-MXFP4-Q4`): 26 frames, 0 `prefill_progress`, `model` rewritten across all frames, `system_fingerprint:"lleme-dev"` on every chunk, final usage chunk has both `prompt_tokens_details.cached_tokens:0` and `completion_tokens_details.reasoning_tokens:0`, `[DONE]` preserved.
- [x] **Manual smoke against SwiftLM non-stream**: same checks pass; `Content-Length: 490` matches body byte count exactly.
- [x] **Manual smoke against llama.cpp** (`unsloth/Llama-3.2-1B-Instruct-GGUF`, both stream + non-stream): `system_fingerprint:"b8851-e365e658f"` (the actual llama-server build hash) is preserved untouched on every frame — additive contract holds. `timings` extension passes through. `model` rewritten as expected.
- [x] **Manual smoke against `/v1/messages` (Anthropic) routing to MLX**: clean Anthropic event sequence (`message_start`, `content_block_start`, 16× `content_block_delta`, `content_block_stop`, `message_delta`, `message_stop`), zero `prefill_progress` leakage into the translator.

Coverage: normalize package 90.7%, full proxy package 51.7% (was 48.7%).